### PR TITLE
Fix a few types, and return promise from generateDeclarations

### DIFF
--- a/src/gen-ts.ts
+++ b/src/gen-ts.ts
@@ -227,8 +227,8 @@ const typeMap = new Map([
   ['String', 'string'],
   ['Number', 'number'],
   ['Boolean', 'boolean'],
-  ['*', '{}'],
-  ['Array', '{}[]'],
+  ['*', 'any'],
+  ['Array', 'any[]'],
 ]);
 
 interface TsType {
@@ -239,8 +239,7 @@ interface TsType {
 function getTsType(type?: string): TsType {
   let optional = false;
 
-  // default to '{}' in preference to 'any'
-  type = type || '{}';
+  type = type || 'any';
   
   // handle Closure optionals
   if (type.endsWith('=')) {
@@ -250,7 +249,7 @@ function getTsType(type?: string): TsType {
 
   // handle Closure unknown type
   if (type.startsWith('?')) {
-    type = '{}';
+    type = type + '|null';
   }
 
   // convert from Closure

--- a/src/gen-ts.ts
+++ b/src/gen-ts.ts
@@ -227,7 +227,8 @@ const typeMap = new Map([
   ['String', 'string'],
   ['Number', 'number'],
   ['Boolean', 'boolean'],
-  ['Array', 'any[]'],
+  ['*', '{}'],
+  ['Array', '{}[]'],
 ]);
 
 interface TsType {
@@ -238,13 +239,18 @@ interface TsType {
 function getTsType(type?: string): TsType {
   let optional = false;
 
-  // default to 'any'
-  type = type || 'any';
+  // default to '{}' in preference to 'any'
+  type = type || '{}';
   
   // handle Closure optionals
   if (type.endsWith('=')) {
     optional = true;
     type = type.substring(0, type.length - 1);
+  }
+
+  // handle Closure unknown type
+  if (type.startsWith('?')) {
+    type = '{}';
   }
 
   // convert from Closure

--- a/src/gen-ts.ts
+++ b/src/gen-ts.ts
@@ -1,6 +1,6 @@
 // Requires node >= 7.6
 
-import { Analyzer, Feature, Element, Package, FSUrlLoader, PackageUrlResolver, Property, ElementMixin, Method } from 'polymer-analyzer';
+import { Analyzer, Feature, Element, Analysis, FSUrlLoader, PackageUrlResolver, Property, ElementMixin, Method } from 'polymer-analyzer';
 import { Function as ResolvedFunction} from 'polymer-analyzer/lib/javascript/function';
 import { generate } from 'escodegen';
 
@@ -15,16 +15,16 @@ const header = `declare namespace Polymer {
 `;
 const footer = `}`;
 
-export function generateDeclarations() {
+export function generateDeclarations(): Promise<string> {
   const analyzer = new Analyzer({
     urlLoader: new FSUrlLoader(),
     urlResolver: new PackageUrlResolver(),
   });
 
-  analyzer.analyzePackage().then(generatePackage);
+  return analyzer.analyzePackage().then(generatePackage);
 }
 
-function generatePackage(pkg: Package) {
+function generatePackage(pkg: Analysis): Promise<string> {
   const declarations = [header];
   
   for (const feature of pkg.getFeatures()) {
@@ -48,7 +48,7 @@ function generatePackage(pkg: Package) {
 
   declarations.push(footer);
 
-  process.stdout.write(declarations.join('\n'));
+  return Promise.resolve(declarations.join('\n'));
 }
 
 function genElementDeclaration(element: Element, declarations: string[], indent: number = 0) {


### PR DESCRIPTION
Hi all,
Just trying to pitch in a little and get this thing going. There's a chance some of these won't strike your fancy, so just let me know and I'll remove them.

* Polymer-Analyzer now uses the "Analysis" class to return the AST. Changed accordingly.
* Looks like gen-closure-declarations is returning a promise instead of writing directly to stdout, so I changed it to match, in order to run it the same way gen-closure-declarations runs it.
* Converted the use of "any" to "{} per TypeScript style guide.
* Converted "*" types to "{}" as "*" is invalid in TypeScript
* Converted closure "UNKNOWN" types ("?string") to "{}"