### PR TITLE
Define a simplified TypeScript AST, and a serializer that produces d.ts declarations.

### DIFF
--- a/src/test/ts-serialize_test.ts
+++ b/src/test/ts-serialize_test.ts
@@ -1,0 +1,222 @@
+import {assert} from 'chai';
+
+import {Class, Function, Interface, Property} from '../ts-ast';
+import {serializeTsDeclarations} from '../ts-serialize';
+
+suite('serializeTsDeclarations', () => {
+  test('property', () => {
+    const property: Property = {
+      kind: 'property',
+      name: 'myProperty',
+      description: '',
+      type: 'string',
+    };
+    assert.equal(serializeTsDeclarations(property), 'myProperty: string;\n');
+  });
+
+  test('property with unsafe name', () => {
+    const property: Property = {
+      kind: 'property',
+      name: 'my-unsafe-property',
+      description: '',
+      type: 'string',
+    };
+    assert.equal(
+        serializeTsDeclarations(property), '"my-unsafe-property": string;\n');
+  });
+
+  test('method with description', () => {
+    const method: Function = {
+      kind: 'function',
+      name: 'MyMethod',
+      description: 'This is my method.\nIt has a multi-line description.',
+      params: [
+        {
+          kind: 'param',
+          name: 'param1',
+          type: 'string',
+        },
+        {
+          kind: 'param',
+          name: 'param2',
+          type: 'any',
+        },
+      ],
+      returns: 'boolean',
+    };
+    assert.equal(serializeTsDeclarations(method), `
+/**
+ * This is my method.
+ * It has a multi-line description.
+ */
+MyMethod(param1: string, param2: any): boolean;
+`);
+  });
+
+  test('interface', () => {
+    const i: Interface = {
+      kind: 'interface',
+      name: 'MyInterface',
+      extends: [
+        'MyBase1',
+        'MyBase2',
+      ],
+      properties: [
+        {
+          kind: 'property',
+          name: 'myProperty1',
+          description: 'Description of myProperty1.',
+          type: 'string',
+        },
+        {
+          kind: 'property',
+          name: 'myProperty2',
+          description: 'Description of myProperty2.',
+          type: 'any',
+        },
+      ],
+      methods: [
+        {
+          kind: 'function',
+          name: 'MyMethod1',
+          description: '',
+          params: [],
+          returns: 'boolean',
+        },
+        {
+          kind: 'function',
+          name: 'MyMethod2',
+          description: '',
+          params: [],
+          returns: 'any',
+        },
+      ],
+    };
+    assert.equal(
+        serializeTsDeclarations(i),
+        `interface MyInterface extends MyBase1, MyBase2 {
+
+  /**
+   * Description of myProperty1.
+   */
+  myProperty1: string;
+
+  /**
+   * Description of myProperty2.
+   */
+  myProperty2: any;
+  MyMethod1(): boolean;
+  MyMethod2(): any;
+}
+`);
+  });
+
+  test('class', () => {
+    const c: Class = {
+      kind: 'class',
+      name: 'MyClass',
+      extends: 'MyBase',
+      properties: [
+        {
+          kind: 'property',
+          name: 'myProperty1',
+          description: '',
+          type: 'string',
+        },
+        {
+          kind: 'property',
+          name: 'myProperty2',
+          description: '',
+          type: 'any',
+        },
+      ],
+      methods: [
+        {
+          kind: 'function',
+          name: 'MyMethod1',
+          description: '',
+          params: [],
+          returns: 'boolean',
+        },
+        {
+          kind: 'function',
+          name: 'MyMethod2',
+          description: '',
+          params: [],
+          returns: 'any',
+        },
+      ],
+    };
+    assert.equal(serializeTsDeclarations(c), `class MyClass extends MyBase {
+  myProperty1: string;
+  myProperty2: any;
+  MyMethod1(): boolean;
+  MyMethod2(): any;
+}
+`);
+  });
+
+  test('namespace', () => {
+    assert.equal(
+        serializeTsDeclarations({
+          kind: 'namespace',
+          name: 'MyNamespace',
+          members: [
+            {
+              kind: 'interface',
+              name: 'MyInterface',
+              extends: [],
+              properties: [],
+              methods: []
+            },
+          ],
+        }),
+        `namespace MyNamespace {
+
+  interface MyInterface {
+  }
+}
+`);
+  });
+
+  test('deep namespace', () => {
+    assert.equal(
+        serializeTsDeclarations({
+          kind: 'namespace',
+          name: 'MyNamespace1',
+          members: [
+            {
+              kind: 'namespace',
+              name: 'MyNamespace2',
+              members: [
+                {
+                  kind: 'namespace',
+                  name: 'MyNamespace3',
+                  members: [
+                    {
+                      kind: 'interface',
+                      name: 'MyInterface',
+                      extends: [],
+                      properties: [],
+                      methods: []
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }),
+        `namespace MyNamespace1 {
+
+  namespace MyNamespace2 {
+
+    namespace MyNamespace3 {
+
+      interface MyInterface {
+      }
+    }
+  }
+}
+`);
+  });
+});

--- a/src/ts-ast.ts
+++ b/src/ts-ast.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+export interface Namespace {
+  kind: 'namespace';
+  name: string;
+  members: Array<Namespace|Class|Interface|Function>;
+}
+
+export interface Class {
+  kind: 'class';
+  name: string;
+  extends: string;
+  properties: Property[];
+  methods: Function[];
+}
+
+export interface Interface {
+  kind: 'interface';
+  name: string;
+  extends: string[];
+  properties: Property[];
+  methods: Function[];
+}
+
+export interface Function {
+  kind: 'function';
+  name: string;
+  description: string;
+  params: Param[];
+  returns: string;
+}
+
+export interface Property {
+  kind: 'property';
+  name: string;
+  description: string;
+  type: string;
+}
+
+export interface Param {
+  kind: 'param';
+  name: string;
+  type: string;
+}

--- a/src/ts-serialize.ts
+++ b/src/ts-serialize.ts
@@ -1,0 +1,128 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+import * as util from 'util';
+
+import {Class, Function, Interface, Namespace, Property} from './ts-ast';
+
+/**
+ * Encode a TypeScript AST node in TypeScript declaration file syntax (d.ts).
+ */
+export function serializeTsDeclarations(
+    node: Namespace|Class|Interface|Function|Property,
+    depth: number = 0): string {
+  switch (node.kind) {
+    case 'namespace':
+      return serializeNamespace(node, depth);
+    case 'class':
+      return serializeClass(node, depth);
+    case 'interface':
+      return serializeInterface(node, depth);
+    case 'function':
+      return serializeMethod(node, depth);
+    case 'property':
+      return serializeProperty(node, depth);
+    default:
+      const never: never = node;
+      throw new Error(`Unknown node kind: ${util.inspect(never)}`);
+  }
+}
+
+function serializeNamespace(node: Namespace, depth: number): string {
+  const i = indent(depth)
+  let out = `${i}namespace ${node.name} {\n`;
+  for (const member of node.members) {
+    out += '\n' + serializeTsDeclarations(member, depth + 1);
+  }
+  out += `${i}}\n`;
+  return out;
+}
+
+function serializeClass(node: Class|Interface, depth: number): string {
+  const i = indent(depth);
+  let out = `${i}${node.kind} ${node.name}`;
+  if (node.extends) {
+    out += ' extends ' + node.extends;
+  }
+  out += ' {\n';
+  for (const property of node.properties) {
+    out += serializeProperty(property, depth + 1);
+  }
+  for (const method of node.methods) {
+    out += serializeMethod(method, depth + 1);
+  }
+  if (!out.endsWith('\n')) {
+    out += '\n';
+  }
+  out += `${i}}\n`;
+  return out;
+}
+
+function serializeInterface(node: Interface, depth: number): string {
+  const i = indent(depth);
+  let out = `${i}${node.kind} ${node.name}`;
+  if (node.extends.length) {
+    out += ' extends ' + node.extends.join(', ');
+  }
+  out += ' {\n';
+  for (const property of node.properties) {
+    out += serializeProperty(property, depth + 1);
+  }
+  for (const method of node.methods) {
+    out += serializeMethod(method, depth + 1);
+  }
+  if (!out.endsWith('\n')) {
+    out += '\n';
+  }
+  out += `${i}}\n`;
+  return out;
+}
+
+function serializeMethod(node: Function, depth: number): string {
+  const i = indent(depth);
+  let out = '';
+  if (node.description) {
+    out += '\n' + formatComment(node.description, depth);
+  }
+  out += `${i}${node.name}(`;
+  out += node.params.map(({name, type}) => `${name}: ${type}`).join(', ');
+  out += `): ${node.returns};\n`;
+  return out;
+}
+
+function serializeProperty(node: Property, depth: number): string {
+  const i = indent(depth);
+  let out = '';
+  if (node.description) {
+    out += '\n' + formatComment(node.description, depth);
+  }
+  out += `${i}${quotePropertyName(node.name)}: ${node.type};\n`;
+  return out;
+}
+
+function quotePropertyName(name: string): string {
+  // TODO We should escape reserved words, and there are many more safe
+  // characters than are included in this RegExp.
+  // See https://mathiasbynens.be/notes/javascript-identifiers-es6
+  const safe = name.match(/^[_$a-zA-Z][_$a-zA-Z0-9]*$/);
+  return safe ? name : JSON.stringify(name);
+}
+
+const indentSpaces = 2;
+
+function indent(depth: number): string {
+  return ' '.repeat(depth * indentSpaces);
+}
+
+function formatComment(comment: string, depth: number): string {
+  const i = indent(depth);
+  return `${i}/**\n` + comment.replace(/^/gm, `${i} * `) + `\n${i} */\n`;
+}


### PR DESCRIPTION
The idea here is to separate generation of type declarations into two stages. 1) Traverse the Analyzer output and map it to TypeScript space using these AST types, and 2) Serialize the AST to a d.ts file. This PR adds the AST interfaces, and the serialization logic.

I think this should make it easier to work on the "how do we map analyzer output to TypeScript" problem without worrying about the text formatting of the d.ts file.