### PR TITLE
Augment HTMLElementTagNameMap when we encounter a custom element.

### DIFF
--- a/src/test/goldens/paper-button/paper-button.d.ts
+++ b/src/test/goldens/paper-button/paper-button.d.ts
@@ -71,3 +71,7 @@ interface PaperButton extends Polymer.Element, Polymer.PaperButtonBehavior {
   raised: boolean;
   _calculateElevation(): any;
 }
+
+interface HTMLElementTagNameMap {
+  "paper-button": PaperButton;
+}

--- a/src/test/goldens/polymer/lib/elements/array-selector.d.ts
+++ b/src/test/goldens/polymer/lib/elements/array-selector.d.ts
@@ -62,3 +62,7 @@ declare namespace Polymer {
   interface ArraySelector extends Polymer.Element {
   }
 }
+
+interface HTMLElementTagNameMap {
+  "array-selector": Polymer.ArraySelector;
+}

--- a/src/test/goldens/polymer/lib/elements/custom-style.d.ts
+++ b/src/test/goldens/polymer/lib/elements/custom-style.d.ts
@@ -51,3 +51,7 @@ declare namespace Polymer {
     getStyle(): HTMLStyleElement|null;
   }
 }
+
+interface HTMLElementTagNameMap {
+  "custom-style": Polymer.CustomStyle;
+}

--- a/src/test/goldens/polymer/lib/elements/dom-bind.d.ts
+++ b/src/test/goldens/polymer/lib/elements/dom-bind.d.ts
@@ -28,3 +28,7 @@ declare namespace Polymer {
     render(): any;
   }
 }
+
+interface HTMLElementTagNameMap {
+  "dom-bind": Polymer.DomBind;
+}

--- a/src/test/goldens/polymer/lib/elements/dom-if.d.ts
+++ b/src/test/goldens/polymer/lib/elements/dom-if.d.ts
@@ -49,3 +49,7 @@ declare namespace Polymer {
     _showHideChildren(): any;
   }
 }
+
+interface HTMLElementTagNameMap {
+  "dom-if": Polymer.DomIf;
+}

--- a/src/test/goldens/polymer/lib/elements/dom-module.d.ts
+++ b/src/test/goldens/polymer/lib/elements/dom-module.d.ts
@@ -30,3 +30,7 @@ declare namespace Polymer {
     register(id?: string): any;
   }
 }
+
+interface HTMLElementTagNameMap {
+  "dom-module": Polymer.DomModule;
+}

--- a/src/test/goldens/polymer/lib/elements/dom-repeat.d.ts
+++ b/src/test/goldens/polymer/lib/elements/dom-repeat.d.ts
@@ -254,3 +254,7 @@ declare namespace Polymer {
     modelForElement(el: HTMLElement|null): TemplateInstanceBase|null;
   }
 }
+
+interface HTMLElementTagNameMap {
+  "dom-repeat": Polymer.DomRepeat;
+}


### PR DESCRIPTION
The `HTMLElementTagNameMap` global interface maps custom element tag names to their definitions, so that TypeScript knows that e.g. `dom.createElement('my-foo')` returns a `MyFoo`. Now we augment that map when we encounter a custom element definition.