### PR TITLE
Split Closure type expression parsing from TypeScript serialization.

### DIFF
--- a/src/gen-ts.ts
+++ b/src/gen-ts.ts
@@ -150,7 +150,7 @@ function handleElementOrBehavior(
       kind: 'property',
       name: property.name || '',
       description: property.description || '',
-      type: property.type ? closureTypeToTypeScript(property.type) : 'any',
+      type: property.type ? closureTypeToTypeScript(property.type) : ts.anyType,
     });
   }
 
@@ -176,7 +176,7 @@ function handleElementOrBehavior(
       params: params,
       returns: method.return && method.return.type ?
           closureTypeToTypeScript(method.return.type) :
-          'any',
+          ts.anyType,
     });
   }
 
@@ -199,7 +199,7 @@ function handleElementOrBehavior(
       kind: 'property',
       name: feature.tagName,
       description: '',
-      type: fullName,
+      type: {kind: 'name', name: fullName},
     });
   }
 }
@@ -229,7 +229,7 @@ function handleFunction(feature: AnalyzerFunction, root: ts.Document) {
     params: params,
     returns: feature.return && feature.return.type ?
         closureTypeToTypeScript(feature.return.type) :
-        'any',
+        ts.anyType,
   });
 }
 

--- a/src/test/closure-types_test.ts
+++ b/src/test/closure-types_test.ts
@@ -12,11 +12,12 @@
 import {assert} from 'chai';
 
 import {closureParamToTypeScript, closureTypeToTypeScript} from '../closure-types';
+import {serializeType} from '../ts-serialize';
 
 suite('closureTypeToTypeScript', () => {
 
   function check(closureType: string, expectedType: string) {
-    const actualType = closureTypeToTypeScript(closureType);
+    const actualType = serializeType(closureTypeToTypeScript(closureType));
     assert.equal(actualType, expectedType);
   }
 
@@ -120,8 +121,10 @@ suite('closureParamToTypeScript', () => {
 
   function check(
       closureType: string, expectedType: string, expectedOptional: boolean) {
-    const actual = closureParamToTypeScript(closureType);
-    assert.deepEqual(actual, {type: expectedType, optional: expectedOptional});
+    const {type: actualType, optional: actualOptional} =
+        closureParamToTypeScript(closureType);
+    assert.equal(serializeType(actualType), expectedType);
+    assert.equal(actualOptional, expectedOptional);
   }
 
   test('optional string', () => {

--- a/src/test/closure-types_test.ts
+++ b/src/test/closure-types_test.ts
@@ -59,18 +59,18 @@ suite('closureTypeToTypeScript', () => {
   });
 
   test('nullable array', () => {
-    check('Array<string>', 'Array<string>|null');
-    check('?Array<string>', 'Array<string>|null');
+    check('Array<string>', 'string[]|null');
+    check('?Array<string>', 'string[]|null');
   });
 
   test('non-nullable array', () => {
-    check('!Array<string>', 'Array<string>');
+    check('!Array<string>', 'string[]');
   });
 
   test('bare array', () => {
-    check('Array', 'Array<any>|null');
-    check('?Array', 'Array<any>|null');
-    check('!Array', 'Array<any>');
+    check('Array', 'any[]|null');
+    check('?Array', 'any[]|null');
+    check('!Array', 'any[]');
   });
 
   test('union', () => {
@@ -89,7 +89,7 @@ suite('closureTypeToTypeScript', () => {
   });
 
   test('nested array', () => {
-    check('!Array<!Array<string>>', 'Array<Array<string>>');
+    check('!Array<!Array<string>>', 'Array<string[]>');
   });
 
   test('array union', () => {
@@ -136,11 +136,11 @@ suite('closureParamToTypeScript', () => {
   });
 
   test('optional array', () => {
-    check('Array=', 'Array<any>|null', true);
+    check('Array=', 'any[]|null', true);
   });
 
   test('required array', () => {
-    check('Array', 'Array<any>|null', false);
+    check('Array', 'any[]|null', false);
   });
 
   test('invalid required', () => {

--- a/src/test/goldens/polymer/lib/elements/dom-repeat.d.ts
+++ b/src/test/goldens/polymer/lib/elements/dom-repeat.d.ts
@@ -93,7 +93,7 @@ declare namespace Polymer {
      * An array containing items determining how many instances of the template
      * to stamp and that that each template instance should bind to.
      */
-    items: Array<any>|null;
+    items: any[]|null;
 
     /**
      * The name of the variable to add to the binding scope for the array

--- a/src/test/goldens/polymer/lib/legacy/class.d.ts
+++ b/src/test/goldens/polymer/lib/legacy/class.d.ts
@@ -8,7 +8,7 @@ declare namespace Polymer {
    * to ensure that any legacy behaviors can rely on legacy Polymer API on
    * the underlying element.
    */
-  function mixinBehaviors(behaviors: Object|null|Array<any>|null, klass: HTMLElement|(() => any)): () => any;
+  function mixinBehaviors(behaviors: Object|null|any[]|null, klass: HTMLElement|(() => any)): () => any;
 
 
   /**

--- a/src/test/goldens/polymer/lib/utils/path.d.ts
+++ b/src/test/goldens/polymer/lib/utils/path.d.ts
@@ -98,7 +98,7 @@ declare namespace Polymer {
      * Polymer.Path.split('foo.bar.0.baz')        // ['foo', 'bar', '0', 'baz']
      * ```
      */
-    function split(path: string|Array<string|number>): Array<string>;
+    function split(path: string|Array<string|number>): string[];
 
 
     /**

--- a/src/test/goldens/polymer/lib/utils/render-status.d.ts
+++ b/src/test/goldens/polymer/lib/utils/render-status.d.ts
@@ -13,7 +13,7 @@ declare namespace Polymer {
      * 
      * Tasks in this queue may be flushed by calling `Polymer.RenderStatus.flush()`.
      */
-    function beforeNextRender(context: any, callback: () => any, args: Array<any>|null): any;
+    function beforeNextRender(context: any, callback: () => any, args: any[]|null): any;
 
 
     /**
@@ -25,6 +25,6 @@ declare namespace Polymer {
      * first paint.  Typical non-render-critical work may include adding UI
      * event listeners and aria attributes.
      */
-    function afterNextRender(context: any, callback: () => any, args: Array<any>|null): any;
+    function afterNextRender(context: any, callback: () => any, args: any[]|null): any;
   }
 }

--- a/src/test/serialize_test.ts
+++ b/src/test/serialize_test.ts
@@ -9,7 +9,7 @@ suite('serializeTsDeclarations', () => {
       kind: 'property',
       name: 'myProperty',
       description: '',
-      type: 'string',
+      type: {kind: 'name', name: 'string'},
     };
     assert.equal(serializeTsDeclarations(property), 'myProperty: string;\n');
   });
@@ -19,7 +19,7 @@ suite('serializeTsDeclarations', () => {
       kind: 'property',
       name: 'my-unsafe-property',
       description: '',
-      type: 'string',
+      type: {kind: 'name', name: 'string'},
     };
     assert.equal(
         serializeTsDeclarations(property), '"my-unsafe-property": string;\n');
@@ -34,17 +34,17 @@ suite('serializeTsDeclarations', () => {
         {
           kind: 'param',
           name: 'param1',
-          type: 'string',
+          type: {kind: 'name', name: 'string'},
           optional: false,
         },
         {
           kind: 'param',
           name: 'param2',
-          type: 'any',
+          type: {kind: 'name', name: 'any'},
           optional: true,
         },
       ],
-      returns: 'boolean',
+      returns: {kind: 'name', name: 'boolean'},
     };
     assert.equal(serializeTsDeclarations(method), `
 /**
@@ -69,13 +69,13 @@ declare function MyMethod(param1: string, param2?: any): boolean;
           kind: 'property',
           name: 'myProperty1',
           description: 'Description of myProperty1.',
-          type: 'string',
+          type: {kind: 'name', name: 'string'},
         },
         {
           kind: 'property',
           name: 'myProperty2',
           description: 'Description of myProperty2.',
-          type: 'any',
+          type: {kind: 'name', name: 'any'},
         },
       ],
       methods: [
@@ -84,14 +84,14 @@ declare function MyMethod(param1: string, param2?: any): boolean;
           name: 'MyMethod1',
           description: '',
           params: [],
-          returns: 'boolean',
+          returns: {kind: 'name', name: 'boolean'},
         },
         {
           kind: 'method',
           name: 'MyMethod2',
           description: '',
           params: [],
-          returns: 'any',
+          returns: {kind: 'name', name: 'any'},
         },
       ],
     };
@@ -126,13 +126,13 @@ interface MyInterface extends MyBase1, MyBase2 {
           kind: 'property',
           name: 'myProperty1',
           description: '',
-          type: 'string',
+          type: {kind: 'name', name: 'string'},
         },
         {
           kind: 'property',
           name: 'myProperty2',
           description: '',
-          type: 'any',
+          type: {kind: 'name', name: 'any'},
         },
       ],
       methods: [
@@ -141,14 +141,14 @@ interface MyInterface extends MyBase1, MyBase2 {
           name: 'MyMethod1',
           description: '',
           params: [],
-          returns: 'boolean',
+          returns: {kind: 'name', name: 'boolean'},
         },
         {
           kind: 'method',
           name: 'MyMethod2',
           description: '',
           params: [],
-          returns: 'any',
+          returns: {kind: 'name', name: 'any'},
         },
       ],
     };

--- a/src/ts-ast.ts
+++ b/src/ts-ast.ts
@@ -43,7 +43,7 @@ export interface FunctionLike {
   name: string;
   description: string;
   params: Param[];
-  returns: string;
+  returns: Type;
 }
 
 export interface Function extends FunctionLike { kind: 'function'; }
@@ -54,12 +54,61 @@ export interface Property {
   kind: 'property';
   name: string;
   description: string;
-  type: string;
+  type: Type;
 }
 
 export interface Param {
   kind: 'param';
   name: string;
-  type: string;
+  type: Type;
   optional: boolean;
 }
+
+// A TypeScript type expression.
+export type Type = NameType|UnionType|ArrayType|FunctionType;
+
+// string, MyClass, null, undefined, any
+export interface NameType {
+  kind: 'name';
+  name: string;
+}
+
+// foo|bar
+export interface UnionType {
+  kind: 'union';
+  members: Type[];
+}
+
+// Array<foo>
+export interface ArrayType {
+  kind: 'array';
+  itemType: Type;
+}
+
+// (foo: bar) => baz
+export interface FunctionType {
+  kind: 'function';
+  params: ParamType[];
+  returns: Type;
+}
+
+// foo: bar
+export interface ParamType {
+  name: string;
+  type: Type;
+}
+
+export const anyType: NameType = {
+  kind: 'name',
+  name: 'any',
+};
+
+export const nullType: NameType = {
+  kind: 'name',
+  name: 'null',
+};
+
+export const undefinedType: NameType = {
+  kind: 'name',
+  name: 'undefined',
+};

--- a/src/ts-serialize.ts
+++ b/src/ts-serialize.ts
@@ -49,7 +49,14 @@ export function serializeType(
       return node.name;
 
     case 'array':
-      return `Array<${serializeType(node.itemType)}>`;
+      if (node.itemType.kind === 'name') {
+        // Use the concise `foo[]` syntax when the item type is simple.
+        return `${serializeType(node.itemType)}[]`;
+      } else {
+        // Otherwise use the `Array<foo>` syntax which is easier to read with
+        // complex types (e.g. arrays of arrays).
+        return `Array<${serializeType(node.itemType)}>`;
+      }
 
     case 'union':
       return node.members.map((member) => serializeType(member, true))

--- a/src/ts-serialize.ts
+++ b/src/ts-serialize.ts
@@ -11,13 +11,14 @@
 
 import * as util from 'util';
 
-import {Class, Document, Function, Interface, Method, Namespace, Param, Property} from './ts-ast';
+import * as ts from './ts-ast';
 
 /**
- * Encode a TypeScript AST node in TypeScript declaration file syntax (d.ts).
+ * Serialize a TypeScript declarations file AST to a string.
  */
 export function serializeTsDeclarations(
-    node: Document|Namespace|Class|Interface|Function|Property,
+    node: ts.Document|ts.Namespace|ts.Class|ts.Interface|ts.Function|
+    ts.Property,
     depth: number = 0): string {
   switch (node.kind) {
     case 'document':
@@ -34,15 +35,45 @@ export function serializeTsDeclarations(
       return serializeProperty(node, depth);
     default:
       const never: never = node;
-      throw new Error(`Unknown node kind: ${util.inspect(never)}`);
+      throw new Error(`Unknown declarations AST kind: ${util.inspect(never)}`);
   }
 }
 
-function serializeDocument(node: Document): string {
+/**
+ * Serialize a TypeScript type expression AST to a string.
+ */
+export function serializeType(
+    node: ts.Type, maybeParenthesize = false): string {
+  switch (node.kind) {
+    case 'name':
+      return node.name;
+
+    case 'array':
+      return `Array<${serializeType(node.itemType)}>`;
+
+    case 'union':
+      return node.members.map((member) => serializeType(member, true))
+          .join('|');
+
+    case 'function':
+      const params = node.params.map(
+          (param) => `${param.name}: ${serializeType(param.type)}`);
+      const func = `(${params.join(', ')}) => ${serializeType(node.returns)}`;
+      // The function syntax is ambiguous when part of a union, so add parens
+      // (e.g. `() => string|null` vs `(() => string)|null`).
+      return maybeParenthesize ? `(${func})` : func;
+
+    default:
+      const never: never = node;
+      throw new Error(`Unknown type AST kind: ${util.inspect(never)}`);
+  }
+}
+
+function serializeDocument(node: ts.Document): string {
   return node.members.map((m) => serializeTsDeclarations(m)).join('\n');
 }
 
-function serializeNamespace(node: Namespace, depth: number): string {
+function serializeNamespace(node: ts.Namespace, depth: number): string {
   let out = ''
   const i = indent(depth)
   out += i
@@ -57,7 +88,7 @@ function serializeNamespace(node: Namespace, depth: number): string {
   return out;
 }
 
-function serializeClass(node: Class|Interface, depth: number): string {
+function serializeClass(node: ts.Class|ts.Interface, depth: number): string {
   let out = '';
   const i = indent(depth);
   if (node.description) {
@@ -85,7 +116,7 @@ function serializeClass(node: Class|Interface, depth: number): string {
   return out;
 }
 
-function serializeInterface(node: Interface, depth: number): string {
+function serializeInterface(node: ts.Interface, depth: number): string {
   let out = '';
   const i = indent(depth);
   if (node.description) {
@@ -111,7 +142,7 @@ function serializeInterface(node: Interface, depth: number): string {
 }
 
 function serializeFunctionOrMethod(
-    node: Function|Method, depth: number): string {
+    node: ts.Function|ts.Method, depth: number): string {
   let out = ''
   const i = indent(depth);
   if (node.description) {
@@ -126,21 +157,22 @@ function serializeFunctionOrMethod(
   }
   out += `${node.name}(`;
   out += node.params.map(serializeParam).join(', ');
-  out += `): ${node.returns};\n`;
+  out += `): ${serializeType(node.returns)};\n`;
   return out;
 }
 
-function serializeParam(param: Param): string {
-  return `${param.name}${param.optional ? '?' : ''}: ${param.type}`;
+function serializeParam(param: ts.Param): string {
+  return `${param.name}${param.optional ? '?' : ''}: ${
+      serializeType(param.type)}`;
 }
 
-function serializeProperty(node: Property, depth: number): string {
+function serializeProperty(node: ts.Property, depth: number): string {
   let out = '';
   const i = indent(depth);
   if (node.description) {
     out += '\n' + formatComment(node.description, depth);
   }
-  out += `${i}${quotePropertyName(node.name)}: ${node.type};\n`;
+  out += `${i}${quotePropertyName(node.name)}: ${serializeType(node.type)};\n`;
   return out;
 }
 


### PR DESCRIPTION
This gives us an intermediate AST for type expressions that we can walk and transform. In particular, this will be helpful for an upcoming PR where we will try to resolve all names in type expressions (e.g. to add triple-slash references, and to warn/replace with `any` when unresolvable).