### PR TITLE
Support mixins.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -295,9 +295,9 @@
       }
     },
     "clang-format": {
-      "version": "1.0.55",
-      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.0.55.tgz",
-      "integrity": "sha1-gDEnEynieneaXQj8Xc4k18UsFNU=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.1.0.tgz",
+      "integrity": "sha512-0Aru49uTLoROl4sPTyO3fvF/NZ+fnGEy5i7bsRwA/bAYT+eWaAxK3sDxRvm/AW7Nwq83BvARH/npeF8OIAaGVQ==",
       "dev": true,
       "requires": {
         "async": "1.5.2",
@@ -600,7 +600,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
       "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "jsonfile": "4.0.0",
@@ -1554,8 +1553,7 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -1707,7 +1705,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11"
       }
@@ -2399,8 +2396,7 @@
     "universalify": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
-      "dev": true
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@types/mocha": "^2.2.43",
     "bower": "^1.8.2",
     "chai": "^4.1.2",
-    "clang-format": "^1.0.55",
+    "clang-format": "^1.1.0",
     "glob": "^7.1.2",
     "mocha": "^3.5.3",
     "source-map-support": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "clean": "rm -rf lib",
-    "format": "find src -name '*.ts' | xargs clang-format --style=file -i",
+    "format": "find src -name '*.ts' -not -path 'src/test/fixtures/*' -not -path 'src/test/goldens/*' | xargs clang-format --style=file -i",
     "build": "npm run clean && tsc",
     "build:watch": "tsc --watch",
     "test": "npm run test:setup-once && npm run build && mocha",

--- a/src/closure-types.ts
+++ b/src/closure-types.ts
@@ -27,7 +27,11 @@ const {parseType, parseParamType} = require('doctrine/lib/typed.js');
  * Convert from a type annotation in Closure syntax to a TypeScript type
  * expression AST (e.g `Array` => `Array<any>|null`).
  */
-export function closureTypeToTypeScript(closureType: string): ts.Type {
+export function closureTypeToTypeScript(closureType: (string|null|undefined)):
+    ts.Type {
+  if (!closureType) {
+    return ts.anyType;
+  }
   let ast;
   try {
     ast = parseType(closureType);
@@ -42,8 +46,11 @@ export function closureTypeToTypeScript(closureType: string): ts.Type {
  * type expression AST
  * (e.g `Array=` => `{type: 'Array<any>|null', optional: true}`).
  */
-export function closureParamToTypeScript(closureType: string):
+export function closureParamToTypeScript(closureType: (string|null|undefined)):
     {optional: boolean, type: ts.Type} {
+  if (!closureType) {
+    return {type: ts.anyType, optional: false};
+  }
   let ast;
   try {
     ast = parseParamType(closureType);

--- a/src/gen-ts.ts
+++ b/src/gen-ts.ts
@@ -232,7 +232,7 @@ function handleFunction(feature: AnalyzerFunction, root: ts.Document) {
 
   const params: ts.Param[] = [];
   for (const param of feature.params || []) {
-    const {optional, type} = closureParamToTypeScript(param.type || '');
+    const {optional, type} = closureParamToTypeScript(param.type);
     params.push({
       kind: 'param',
       name: param.name,
@@ -246,9 +246,7 @@ function handleFunction(feature: AnalyzerFunction, root: ts.Document) {
     name: name,
     description: feature.description || '',
     params: params,
-    returns: feature.return && feature.return.type ?
-        closureTypeToTypeScript(feature.return.type) :
-        ts.anyType,
+    returns: closureTypeToTypeScript(feature.return && feature.return.type),
   });
 }
 
@@ -269,7 +267,7 @@ function handleProperties(analyzerProperties: Iterable<analyzer.Property>):
       description: property.description || '',
       // TODO If this is a Polymer property with no default value, then the
       // type should really be `<type>|undefined`.
-      type: closureTypeToTypeScript(property.type || ''),
+      type: closureTypeToTypeScript(property.type),
     });
   }
   return tsProperties;
@@ -289,7 +287,7 @@ function handleMethods(analyzerMethods: Iterable<analyzer.Method>):
     }
     const params: ts.Param[] = [];
     for (const param of method.params || []) {
-      const {optional, type} = closureParamToTypeScript(param.type || '');
+      const {optional, type} = closureParamToTypeScript(param.type);
       params.push({
         kind: 'param',
         name: param.name,
@@ -302,9 +300,7 @@ function handleMethods(analyzerMethods: Iterable<analyzer.Method>):
       name: method.name || '',
       description: method.description || '',
       params: params,
-      returns: method.return && method.return.type ?
-          closureTypeToTypeScript(method.return.type) :
-          ts.anyType,
+      returns: closureTypeToTypeScript(method.return && method.return.type),
     });
   }
   return tsMethods;

--- a/src/gen-ts.ts
+++ b/src/gen-ts.ts
@@ -99,6 +99,9 @@ function handleDocument(doc: analyzer.Document, root: ts.Document) {
   for (const behavior of doc.getFeatures({kind: 'behavior'})) {
     handleBehavior(behavior, root);
   }
+  for (const mixin of doc.getFeatures({kind: 'element-mixin'})) {
+    handleMixin(mixin, root);
+  }
   for (const fn of doc.getFeatures({kind: 'function'})) {
     handleFunction(fn, root);
   }
@@ -179,6 +182,22 @@ function handleBehavior(feature: analyzer.PolymerBehavior, root: ts.Document) {
     name: className,
     description: feature.description,
     extends: [],
+    properties: handleProperties(feature.properties.values()),
+    methods: handleMethods(feature.methods.values()),
+  });
+}
+
+/**
+ * Add the given Mixin to the given TypeScript declarations document.
+ */
+function handleMixin(feature: analyzer.ElementMixin, root: ts.Document) {
+  const [namespacePath, name] = splitReference(feature.name);
+  const parent = findOrCreateNamespace(root, namespacePath);
+
+  parent.members.push({
+    kind: 'mixin',
+    name: name,
+    description: feature.description || '',
     properties: handleProperties(feature.properties.values()),
     methods: handleMethods(feature.methods.values()),
   });

--- a/src/test/goldens/polymer/lib/elements/array-selector.d.ts
+++ b/src/test/goldens/polymer/lib/elements/array-selector.d.ts
@@ -59,7 +59,9 @@ declare namespace Polymer {
    * });
    * ```
    */
-  interface ArraySelector extends Polymer.Element {
+  class ArraySelector extends
+    Polymer.ArraySelectorMixin(
+    Polymer.Element) {
   }
 
   /**

--- a/src/test/goldens/polymer/lib/elements/array-selector.d.ts
+++ b/src/test/goldens/polymer/lib/elements/array-selector.d.ts
@@ -61,6 +61,98 @@ declare namespace Polymer {
    */
   interface ArraySelector extends Polymer.Element {
   }
+
+  /**
+   * Element mixin for recording dynamic associations between item paths in a
+   * master `items` array and a `selected` array such that path changes to the
+   * master array (at the host) element or elsewhere via data-binding) are
+   * correctly propagated to items in the selected array and vice-versa.
+   * 
+   * The `items` property accepts an array of user data, and via the
+   * `select(item)` and `deselect(item)` API, updates the `selected` property
+   * which may be bound to other parts of the application, and any changes to
+   * sub-fields of `selected` item(s) will be kept in sync with items in the
+   * `items` array.  When `multi` is false, `selected` is a property
+   * representing the last selected item.  When `multi` is true, `selected`
+   * is an array of multiply selected items.
+   */
+  function ArraySelectorMixin<T extends new(...args: any[]) => {}>(base: T): {
+    new(...args: any[]): {
+
+      /**
+       * An array containing items from which selection will be made.
+       */
+      items: any[]|null;
+
+      /**
+       * When `true`, multiple items may be selected at once (in this case,
+       * `selected` is an array of currently selected items).  When `false`,
+       * only one item may be selected at a time.
+       */
+      multi: boolean;
+
+      /**
+       * When `multi` is true, this is an array that contains any selected.
+       * When `multi` is false, this is the currently selected item, or `null`
+       * if no item is selected.
+       */
+      selected: Object|null|Object[]|null|null;
+
+      /**
+       * When `multi` is false, this is the currently selected item, or `null`
+       * if no item is selected.
+       */
+      selectedItem: Object|null;
+
+      /**
+       * When `true`, calling `select` on an item that is already selected
+       * will deselect the item.
+       */
+      toggle: boolean;
+      __updateSelection(multi: any, itemsInfo: any): any;
+      __applySplices(splices: any): any;
+      __updateLinks(): any;
+
+      /**
+       * Clears the selection state.
+       */
+      clearSelection(): any;
+
+      /**
+       * Returns whether the item is currently selected.
+       */
+      isSelected(item: any): boolean;
+
+      /**
+       * Returns whether the item is currently selected.
+       */
+      isIndexSelected(idx: number): boolean;
+      __deselectChangedIdx(idx: any): any;
+      __selectedIndexForItemIndex(idx: any): any;
+
+      /**
+       * Deselects the given item if it is already selected.
+       */
+      deselect(item: any): any;
+
+      /**
+       * Deselects the given index if it is already selected.
+       */
+      deselectIndex(idx: number): any;
+
+      /**
+       * Selects the given item.  When `toggle` is true, this will automatically
+       * deselect the item if already selected.
+       */
+      select(item: any): any;
+
+      /**
+       * Selects the given index.  When `toggle` is true, this will automatically
+       * deselect the item if already selected.
+       */
+      selectIndex(idx: number): any;
+    }
+  } & T
 }
 
 interface HTMLElementTagNameMap {

--- a/src/test/goldens/polymer/lib/elements/custom-style.d.ts
+++ b/src/test/goldens/polymer/lib/elements/custom-style.d.ts
@@ -41,7 +41,7 @@ declare namespace Polymer {
    * </custom-style>
    * ```
    */
-  interface CustomStyle extends Polymer.Element {
+  class CustomStyle extends HTMLElement {
 
     /**
      * Returns the light-DOM `<style>` child this element wraps.  Upon first

--- a/src/test/goldens/polymer/lib/elements/dom-bind.d.ts
+++ b/src/test/goldens/polymer/lib/elements/dom-bind.d.ts
@@ -10,7 +10,11 @@ declare namespace Polymer {
    * document and bind elements to the `dom-bind` element itself as the
    * binding scope.
    */
-  interface DomBind extends Polymer.Element {
+  class DomBind extends
+    Polymer.PropertyEffects(
+    Polymer.OptionalMutableData(
+    Polymer.GestureEventListeners(
+    Polymer.Element))) {
 
     /**
      * assumes only one observed attribute

--- a/src/test/goldens/polymer/lib/elements/dom-if.d.ts
+++ b/src/test/goldens/polymer/lib/elements/dom-if.d.ts
@@ -15,7 +15,7 @@ declare namespace Polymer {
    * Set the `restamp` property to true to force the stamped content to be
    * created / destroyed when the `if` condition changes.
    */
-  interface DomIf extends Polymer.Element {
+  class DomIf extends Polymer.Element {
 
     /**
      * A boolean indicating whether this template should stamp.

--- a/src/test/goldens/polymer/lib/elements/dom-module.d.ts
+++ b/src/test/goldens/polymer/lib/elements/dom-module.d.ts
@@ -19,7 +19,7 @@ declare namespace Polymer {
    * 
    *     let img = customElements.get('dom-module').import('foo', 'img');
    */
-  interface DomModule extends Polymer.Element {
+  class DomModule extends HTMLElement {
     attributeChangedCallback(name: any, old: any, value: any): any;
 
     /**

--- a/src/test/goldens/polymer/lib/elements/dom-repeat.d.ts
+++ b/src/test/goldens/polymer/lib/elements/dom-repeat.d.ts
@@ -87,7 +87,9 @@ declare namespace Polymer {
    *           filter="isEngineer" observe="type manager.type">
    * ```
    */
-  interface DomRepeat extends Polymer.Element {
+  class DomRepeat extends
+    Polymer.OptionalMutableData(
+    Polymer.Element) {
 
     /**
      * An array containing items determining how many instances of the template

--- a/src/test/goldens/polymer/lib/legacy/legacy-element-mixin.d.ts
+++ b/src/test/goldens/polymer/lib/legacy/legacy-element-mixin.d.ts
@@ -1,0 +1,415 @@
+declare namespace Polymer {
+
+  /**
+   * Element class mixin that provides Polymer's "legacy" API intended to be
+   * backward-compatible to the greatest extent possible with the API
+   * found on the Polymer 1.x `Polymer.Base` prototype applied to all elements
+   * defined using the `Polymer({...})` function.
+   */
+  function LegacyElementMixin<T extends new(...args: any[]) => {}>(base: T): {
+    new(...args: any[]): {
+      isAttached: boolean;
+      __boundListeners: any;
+      _debouncers: any;
+
+      /**
+       * Provides an override implementation of `attributeChangedCallback`
+       * which adds the Polymer legacy API's `attributeChanged` method.
+       */
+      attributeChangedCallback(name: string, old: string|null, value: string|null): any;
+
+      /**
+       * Overrides the default `Polymer.PropertyEffects` implementation to
+       * add support for class initialization via the `_registered` callback.
+       * This is called only when the first instance of the element is created.
+       */
+      _initializeProperties(): any;
+
+      /**
+       * Overrides the default `Polymer.PropertyEffects` implementation to
+       * add support for installing `hostAttributes` and `listeners`.
+       */
+      ready(): any;
+
+      /**
+       * Provides an implementation of `connectedCallback`
+       * which adds Polymer legacy API's `attached` method.
+       */
+      connectedCallback(): any;
+
+      /**
+       * Provides an implementation of `disconnectedCallback`
+       * which adds Polymer legacy API's `detached` method.
+       */
+      disconnectedCallback(): any;
+
+      /**
+       * Legacy callback called during the `constructor`, for overriding
+       * by the user.
+       */
+      created(): any;
+
+      /**
+       * Legacy callback called during `connectedCallback`, for overriding
+       * by the user.
+       */
+      attached(): any;
+
+      /**
+       * Legacy callback called during `disconnectedCallback`, for overriding
+       * by the user.
+       */
+      detached(): any;
+
+      /**
+       * Legacy callback called during `attributeChangedChallback`, for overriding
+       * by the user.
+       */
+      attributeChanged(name: string, old: string|null, value: string|null): any;
+
+      /**
+       * Called automatically when an element is initializing.
+       * Users may override this method to perform class registration time
+       * work. The implementation should ensure the work is performed
+       * only once for the class.
+       */
+      _registered(): any;
+
+      /**
+       * Ensures an element has required attributes. Called when the element
+       * is being readied via `ready`. Users should override to set the
+       * element's required attributes. The implementation should be sure
+       * to check and not override existing attributes added by
+       * the user of the element. Typically, setting attributes should be left
+       * to the element user and not done here; reasonable exceptions include
+       * setting aria roles and focusability.
+       */
+      _ensureAttributes(): any;
+
+      /**
+       * Adds element event listeners. Called when the element
+       * is being readied via `ready`. Users should override to
+       * add any required element event listeners.
+       * In performance critical elements, the work done here should be kept
+       * to a minimum since it is done before the element is rendered. In
+       * these elements, consider adding listeners asynchronously so as not to
+       * block render.
+       */
+      _applyListeners(): any;
+
+      /**
+       * Converts a typed JavaScript value to a string.
+       * 
+       * Note this method is provided as backward-compatible legacy API
+       * only.  It is not directly called by any Polymer features. To customize
+       * how properties are serialized to attributes for attribute bindings and
+       * `reflectToAttribute: true` properties as well as this method, override
+       * the `_serializeValue` method provided by `Polymer.PropertyAccessors`.
+       */
+      serialize(value: any): string|undefined;
+
+      /**
+       * Converts a string to a typed JavaScript value.
+       * 
+       * Note this method is provided as backward-compatible legacy API
+       * only.  It is not directly called by any Polymer features.  To customize
+       * how attributes are deserialized to properties for in
+       * `attributeChangedCallback`, override `_deserializeValue` method
+       * provided by `Polymer.PropertyAccessors`.
+       */
+      deserialize(value: string, type: any): any;
+
+      /**
+       * Serializes a property to its associated attribute.
+       * 
+       * Note this method is provided as backward-compatible legacy API
+       * only.  It is not directly called by any Polymer features.
+       */
+      reflectPropertyToAttribute(property: string, attribute?: string, value?: any): any;
+
+      /**
+       * Sets a typed value to an HTML attribute on a node.
+       * 
+       * Note this method is provided as backward-compatible legacy API
+       * only.  It is not directly called by any Polymer features.
+       */
+      serializeValueToAttribute(value: any, attribute: string, node: Element|null): any;
+
+      /**
+       * Copies own properties (including accessor descriptors) from a source
+       * object to a target object.
+       */
+      extend(prototype: Object|null, api: Object|null): Object|null;
+
+      /**
+       * Copies props from a source object to a target object.
+       * 
+       * Note, this method uses a simple `for...in` strategy for enumerating
+       * properties.  To ensure only `ownProperties` are copied from source
+       * to target and that accessor implementations are copied, use `extend`.
+       */
+      mixin(target: Object|null, source: Object|null): Object|null;
+
+      /**
+       * Sets the prototype of an object.
+       * 
+       * Note this method is provided as backward-compatible legacy API
+       * only.  It is not directly called by any Polymer features.
+       */
+      chainObject(object: Object|null, prototype: Object|null): Object|null;
+
+      /**
+       * Calls `importNode` on the `content` of the `template` specified and
+       * returns a document fragment containing the imported content.
+       */
+      instanceTemplate(template: HTMLTemplateElement|null): DocumentFragment|null;
+
+      /**
+       * Dispatches a custom event with an optional detail value.
+       */
+      fire(type: string, detail?: any, options?: any): Event|null;
+
+      /**
+       * Convenience method to add an event listener on a given element,
+       * late bound to a named method on this element.
+       */
+      listen(node: Element|null, eventName: string, methodName: string): any;
+
+      /**
+       * Convenience method to remove an event listener from a given element,
+       * late bound to a named method on this element.
+       */
+      unlisten(node: Element|null, eventName: string, methodName: string): any;
+
+      /**
+       * Override scrolling behavior to all direction, one direction, or none.
+       * 
+       * Valid scroll directions:
+       *   - 'all': scroll in any direction
+       *   - 'x': scroll only in the 'x' direction
+       *   - 'y': scroll only in the 'y' direction
+       *   - 'none': disable scrolling for this node
+       */
+      setScrollDirection(direction?: string, node?: Element|null): any;
+
+      /**
+       * Convenience method to run `querySelector` on this local DOM scope.
+       * 
+       * This function calls `Polymer.dom(this.root).querySelector(slctr)`.
+       */
+      $$(slctr: string): Element|null;
+
+      /**
+       * Force this element to distribute its children to its local dom.
+       * This should not be necessary as of Polymer 2.0.2 and is provided only
+       * for backwards compatibility.
+       */
+      distributeContent(): any;
+
+      /**
+       * Returns a list of nodes that are the effective childNodes. The effective
+       * childNodes list is the same as the element's childNodes except that
+       * any `<content>` elements are replaced with the list of nodes distributed
+       * to the `<content>`, the result of its `getDistributedNodes` method.
+       */
+      getEffectiveChildNodes(): Array<Node|null>|null;
+
+      /**
+       * Returns a list of nodes distributed within this element that match
+       * `selector`. These can be dom children or elements distributed to
+       * children that are insertion points.
+       */
+      queryDistributedElements(selector: string): Array<Node|null>|null;
+
+      /**
+       * Returns a list of elements that are the effective children. The effective
+       * children list is the same as the element's children except that
+       * any `<content>` elements are replaced with the list of elements
+       * distributed to the `<content>`.
+       */
+      getEffectiveChildren(): Array<Node|null>|null;
+
+      /**
+       * Returns a string of text content that is the concatenation of the
+       * text content's of the element's effective childNodes (the elements
+       * returned by <a href="#getEffectiveChildNodes>getEffectiveChildNodes</a>.
+       */
+      getEffectiveTextContent(): string;
+
+      /**
+       * Returns the first effective childNode within this element that
+       * match `selector`. These can be dom child nodes or elements distributed
+       * to children that are insertion points.
+       */
+      queryEffectiveChildren(selector: string): any;
+
+      /**
+       * Returns a list of effective childNodes within this element that
+       * match `selector`. These can be dom child nodes or elements distributed
+       * to children that are insertion points.
+       */
+      queryAllEffectiveChildren(selector: string): Array<Node|null>|null;
+
+      /**
+       * Returns a list of nodes distributed to this element's `<slot>`.
+       * 
+       * If this element contains more than one `<slot>` in its local DOM,
+       * an optional selector may be passed to choose the desired content.
+       */
+      getContentChildNodes(slctr?: string): Array<Node|null>|null;
+
+      /**
+       * Returns a list of element children distributed to this element's
+       * `<slot>`.
+       * 
+       * If this element contains more than one `<slot>` in its
+       * local DOM, an optional selector may be passed to choose the desired
+       * content.  This method differs from `getContentChildNodes` in that only
+       * elements are returned.
+       */
+      getContentChildren(slctr?: string): Array<HTMLElement|null>|null;
+
+      /**
+       * Checks whether an element is in this element's light DOM tree.
+       */
+      isLightDescendant(node: Node|null): boolean;
+
+      /**
+       * Checks whether an element is in this element's local DOM tree.
+       */
+      isLocalDescendant(node?: Element|null): boolean;
+
+      /**
+       * NOTE: should now be handled by ShadyCss library.
+       */
+      scopeSubtree(container: any, shouldObserve: any): any;
+
+      /**
+       * Returns the computed style value for the given property.
+       */
+      getComputedStyleValue(property: string): string;
+
+      /**
+       * Call `debounce` to collapse multiple requests for a named task into
+       * one invocation which is made after the wait time has elapsed with
+       * no new request.  If no wait time is given, the callback will be called
+       * at microtask timing (guaranteed before paint).
+       * 
+       *     debouncedClickAction(e) {
+       *       // will not call `processClick` more than once per 100ms
+       *       this.debounce('click', function() {
+       *        this.processClick();
+       *       } 100);
+       *     }
+       */
+      debounce(jobName: string, callback: () => any, wait: number): Object|null;
+
+      /**
+       * Returns whether a named debouncer is active.
+       */
+      isDebouncerActive(jobName: string): boolean;
+
+      /**
+       * Immediately calls the debouncer `callback` and inactivates it.
+       */
+      flushDebouncer(jobName: string): any;
+
+      /**
+       * Cancels an active debouncer.  The `callback` will not be called.
+       */
+      cancelDebouncer(jobName: string): any;
+
+      /**
+       * Runs a callback function asynchronously.
+       * 
+       * By default (if no waitTime is specified), async callbacks are run at
+       * microtask timing, which will occur before paint.
+       */
+      async(callback: Function|null, waitTime?: number): number;
+
+      /**
+       * Cancels an async operation started with `async`.
+       */
+      cancelAsync(handle: number): any;
+
+      /**
+       * Convenience method for creating an element and configuring it.
+       */
+      create(tag: string, props: Object|null): Element|null;
+
+      /**
+       * Convenience method for importing an HTML document imperatively.
+       * 
+       * This method creates a new `<link rel="import">` element with
+       * the provided URL and appends it to the document to start loading.
+       * In the `onload` callback, the `import` property of the `link`
+       * element will contain the imported document contents.
+       */
+      importHref(href: string, onload: Function|null, onerror: Function|null, optAsync: boolean): HTMLLinkElement|null;
+
+      /**
+       * Polyfill for Element.prototype.matches, which is sometimes still
+       * prefixed.
+       */
+      elementMatches(selector: string, node?: Element|null): boolean;
+
+      /**
+       * Toggles an HTML attribute on or off.
+       */
+      toggleAttribute(name: string, bool?: boolean, node?: Element|null): any;
+
+      /**
+       * Toggles a CSS class on or off.
+       */
+      toggleClass(name: string, bool?: boolean, node?: Element|null): any;
+
+      /**
+       * Cross-platform helper for setting an element's CSS `transform` property.
+       */
+      transform(transformText: string, node?: Element|null): any;
+
+      /**
+       * Cross-platform helper for setting an element's CSS `translate3d`
+       * property.
+       */
+      translate3d(x: number, y: number, z: number, node?: Element|null): any;
+
+      /**
+       * Removes an item from an array, if it exists.
+       * 
+       * If the array is specified by path, a change notification is
+       * generated, so that observers, data bindings and computed
+       * properties watching that path can update.
+       * 
+       * If the array is passed directly, **no change
+       * notification is generated**.
+       */
+      arrayDelete(arrayOrPath: string|Array<number|string>, item: any): any[]|null;
+
+      /**
+       * Facades `console.log`/`warn`/`error` as override point.
+       */
+      _logger(level: string, args: any[]|null): any;
+
+      /**
+       * Facades `console.log` as an override point.
+       */
+      _log(...args: any): any;
+
+      /**
+       * Facades `console.warn` as an override point.
+       */
+      _warn(...args: any): any;
+
+      /**
+       * Facades `console.error` as an override point.
+       */
+      _error(...args: any): any;
+
+      /**
+       * Formats a message using the element type an a method name.
+       */
+      _logf(methodName: string, ...args: any): any[]|null;
+    }
+  } & T
+}

--- a/src/test/goldens/polymer/lib/mixins/element-mixin.d.ts
+++ b/src/test/goldens/polymer/lib/mixins/element-mixin.d.ts
@@ -1,0 +1,151 @@
+declare namespace Polymer {
+
+  /**
+   * Element class mixin that provides the core API for Polymer's meta-programming
+   * features including template stamping, data-binding, attribute deserialization,
+   * and property change observation.
+   * 
+   * Subclassers may provide the following static getters to return metadata
+   * used to configure Polymer's features for the class:
+   * 
+   * - `static get is()`: When the template is provided via a `dom-module`,
+   *   users should return the `dom-module` id from a static `is` getter.  If
+   *   no template is needed or the template is provided directly via the
+   *   `template` getter, there is no need to define `is` for the element.
+   * 
+   * - `static get template()`: Users may provide the template directly (as
+   *   opposed to via `dom-module`) by implementing a static `template` getter.
+   *   The getter may return an `HTMLTemplateElement` or a string, which will
+   *   automatically be parsed into a template.
+   * 
+   * - `static get properties()`: Should return an object describing
+   *   property-related metadata used by Polymer features (key: property name
+   *   value: object containing property metadata). Valid keys in per-property
+   *   metadata include:
+   *   - `type` (String|Number|Object|Array|...): Used by
+   *     `attributeChangedCallback` to determine how string-based attributes
+   *     are deserialized to JavaScript property values.
+   *   - `notify` (boolean): Causes a change in the property to fire a
+   *     non-bubbling event called `<property>-changed`. Elements that have
+   *     enabled two-way binding to the property use this event to observe changes.
+   *   - `readOnly` (boolean): Creates a getter for the property, but no setter.
+   *     To set a read-only property, use the private setter method
+   *     `_setProperty(property, value)`.
+   *   - `observer` (string): Observer method name that will be called when
+   *     the property changes. The arguments of the method are
+   *     `(value, previousValue)`.
+   *   - `computed` (string): String describing method and dependent properties
+   *     for computing the value of this property (e.g. `'computeFoo(bar, zot)'`).
+   *     Computed properties are read-only by default and can only be changed
+   *     via the return value of the computing method.
+   * 
+   * - `static get observers()`: Array of strings describing multi-property
+   *   observer methods and their dependent properties (e.g.
+   *   `'observeABC(a, b, c)'`).
+   * 
+   * The base class provides default implementations for the following standard
+   * custom element lifecycle callbacks; users may override these, but should
+   * call the super method to ensure
+   * - `constructor`: Run when the element is created or upgraded
+   * - `connectedCallback`: Run each time the element is connected to the
+   *   document
+   * - `disconnectedCallback`: Run each time the element is disconnected from
+   *   the document
+   * - `attributeChangedCallback`: Run each time an attribute in
+   *   `observedAttributes` is set or removed (note: this element's default
+   *   `observedAttributes` implementation will automatically return an array
+   *   of dash-cased attributes based on `properties`)
+   */
+  function ElementMixin<T extends new(...args: any[]) => {}>(base: T): {
+    new(...args: any[]): {
+      _template: HTMLTemplateElement|null;
+      _importPath: string;
+      rootPath: string;
+      importPath: string;
+      root: StampedTemplate|null|HTMLElement|null|ShadowRoot|null;
+      $: any;
+
+      /**
+       * Provides a default implementation of the standard Custom Elements
+       * `attributeChangedCallback`.
+       * 
+       * By default, attributes declared in `properties` metadata are
+       * deserialized using their `type` information to properties of the
+       * same name.  "Dash-cased" attributes are deserialized to "camelCase"
+       * properties.
+       */
+      attributeChangedCallback(name: string, old: string|null, value: string|null): any;
+
+      /**
+       * Overrides the default `Polymer.PropertyAccessors` to ensure class
+       * metaprogramming related to property accessors and effects has
+       * completed (calls `finalize`).
+       * 
+       * It also initializes any property defaults provided via `value` in
+       * `properties` metadata.
+       */
+      _initializeProperties(): any;
+
+      /**
+       * Stamps the element template.
+       */
+      ready(): any;
+
+      /**
+       * Implements `PropertyEffects`'s `_readyClients` call. Attaches
+       * element dom by calling `_attachDom` with the dom stamped from the
+       * element's template via `_stampTemplate`. Note that this allows
+       * client dom to be attached to the element prior to any observers
+       * running.
+       */
+      _readyClients(): any;
+
+      /**
+       * Provides a default implementation of the standard Custom Elements
+       * `connectedCallback`.
+       * 
+       * The default implementation enables the property effects system and
+       * flushes any pending properties, and updates shimmed CSS properties
+       * when using the ShadyCSS scoping/custom properties polyfill.
+       */
+      connectedCallback(): any;
+
+      /**
+       * Provides a default implementation of the standard Custom Elements
+       * `disconnectedCallback`.
+       */
+      disconnectedCallback(): any;
+
+      /**
+       * Attaches an element's stamped dom to itself. By default,
+       * this method creates a `shadowRoot` and adds the dom to it.
+       * However, this method may be overridden to allow an element
+       * to put its dom in another location.
+       */
+      _attachDom(dom: StampedTemplate|null): ShadowRoot|null;
+
+      /**
+       * When using the ShadyCSS scoping and custom property shim, causes all
+       * shimmed styles in this element (and its subtree) to be updated
+       * based on current custom property values.
+       * 
+       * The optional parameter overrides inline custom property styles with an
+       * object of properties where the keys are CSS properties, and the values
+       * are strings.
+       * 
+       * Example: `this.updateStyles({'--color': 'blue'})`
+       * 
+       * These properties are retained unless a value of `null` is set.
+       */
+      updateStyles(properties?: Object|null): any;
+
+      /**
+       * Rewrites a given URL relative to a base URL. The base URL defaults to
+       * the original location of the document containing the `dom-module` for
+       * this element. This method will return the same URL before and after
+       * bundling.
+       */
+      resolveUrl(url: string, base?: string): string;
+    }
+  } & T
+}

--- a/src/test/goldens/polymer/lib/mixins/gesture-event-listeners.d.ts
+++ b/src/test/goldens/polymer/lib/mixins/gesture-event-listeners.d.ts
@@ -1,0 +1,18 @@
+declare namespace Polymer {
+
+  /**
+   * Element class mixin that provides API for adding Polymer's cross-platform
+   * gesture events to nodes.
+   * 
+   * The API is designed to be compatible with override points implemented
+   * in `Polymer.TemplateStamp` such that declarative event listeners in
+   * templates will support gesture events when this mixin is applied along with
+   * `Polymer.TemplateStamp`.
+   */
+  function GestureEventListeners<T extends new(...args: any[]) => {}>(base: T): {
+    new(...args: any[]): {
+      _addEventListenerToNode(node: any, eventName: any, handler: any): any;
+      _removeEventListenerFromNode(node: any, eventName: any, handler: any): any;
+    }
+  } & T
+}

--- a/src/test/goldens/polymer/lib/mixins/mutable-data.d.ts
+++ b/src/test/goldens/polymer/lib/mixins/mutable-data.d.ts
@@ -1,0 +1,109 @@
+declare namespace Polymer {
+
+  /**
+   * Element class mixin to skip strict dirty-checking for objects and arrays
+   * (always consider them to be "dirty"), for use on elements utilizing
+   * `Polymer.PropertyEffects`
+   * 
+   * By default, `Polymer.PropertyEffects` performs strict dirty checking on
+   * objects, which means that any deep modifications to an object or array will
+   * not be propagated unless "immutable" data patterns are used (i.e. all object
+   * references from the root to the mutation were changed).
+   * 
+   * Polymer also provides a proprietary data mutation and path notification API
+   * (e.g. `notifyPath`, `set`, and array mutation API's) that allow efficient
+   * mutation and notification of deep changes in an object graph to all elements
+   * bound to the same object graph.
+   * 
+   * In cases where neither immutable patterns nor the data mutation API can be
+   * used, applying this mixin will cause Polymer to skip dirty checking for
+   * objects and arrays (always consider them to be "dirty").  This allows a
+   * user to make a deep modification to a bound object graph, and then either
+   * simply re-set the object (e.g. `this.items = this.items`) or call `notifyPath`
+   * (e.g. `this.notifyPath('items')`) to update the tree.  Note that all
+   * elements that wish to be updated based on deep mutations must apply this
+   * mixin or otherwise skip strict dirty checking for objects/arrays.
+   * 
+   * In order to make the dirty check strategy configurable, see
+   * `Polymer.OptionalMutableData`.
+   * 
+   * Note, the performance characteristics of propagating large object graphs
+   * will be worse as opposed to using strict dirty checking with immutable
+   * patterns or Polymer's path notification API.
+   */
+  function MutableData<T extends new(...args: any[]) => {}>(base: T): {
+    new(...args: any[]): {
+
+      /**
+       * Overrides `Polymer.PropertyEffects` to provide option for skipping
+       * strict equality checking for Objects and Arrays.
+       * 
+       * This method pulls the value to dirty check against from the `__dataTemp`
+       * cache (rather than the normal `__data` cache) for Objects.  Since the temp
+       * cache is cleared at the end of a turn, this implementation allows
+       * side-effects of deep object changes to be processed by re-setting the
+       * same object (using the temp cache as an in-turn backstop to prevent
+       * cycles due to 2-way notification).
+       */
+      _shouldPropertyChange(property: string, value: any, old: any): boolean;
+    }
+  } & T
+
+  /**
+   * Element class mixin to add the optional ability to skip strict
+   * dirty-checking for objects and arrays (always consider them to be
+   * "dirty") by setting a `mutable-data` attribute on an element instance.
+   * 
+   * By default, `Polymer.PropertyEffects` performs strict dirty checking on
+   * objects, which means that any deep modifications to an object or array will
+   * not be propagated unless "immutable" data patterns are used (i.e. all object
+   * references from the root to the mutation were changed).
+   * 
+   * Polymer also provides a proprietary data mutation and path notification API
+   * (e.g. `notifyPath`, `set`, and array mutation API's) that allow efficient
+   * mutation and notification of deep changes in an object graph to all elements
+   * bound to the same object graph.
+   * 
+   * In cases where neither immutable patterns nor the data mutation API can be
+   * used, applying this mixin will allow Polymer to skip dirty checking for
+   * objects and arrays (always consider them to be "dirty").  This allows a
+   * user to make a deep modification to a bound object graph, and then either
+   * simply re-set the object (e.g. `this.items = this.items`) or call `notifyPath`
+   * (e.g. `this.notifyPath('items')`) to update the tree.  Note that all
+   * elements that wish to be updated based on deep mutations must apply this
+   * mixin or otherwise skip strict dirty checking for objects/arrays.
+   * 
+   * While this mixin adds the ability to forgo Object/Array dirty checking,
+   * the `mutableData` flag defaults to false and must be set on the instance.
+   * 
+   * Note, the performance characteristics of propagating large object graphs
+   * will be worse by relying on `mutableData: true` as opposed to using
+   * strict dirty checking with immutable patterns or Polymer's path notification
+   * API.
+   */
+  function OptionalMutableData<T extends new(...args: any[]) => {}>(base: T): {
+    new(...args: any[]): {
+
+      /**
+       * Instance-level flag for configuring the dirty-checking strategy
+       * for this element.  When true, Objects and Arrays will skip dirty
+       * checking, otherwise strict equality checking will be used.
+       */
+      mutableData: boolean;
+
+      /**
+       * Overrides `Polymer.PropertyEffects` to provide option for skipping
+       * strict equality checking for Objects and Arrays.
+       * 
+       * When `this.mutableData` is true on this instance, this method
+       * pulls the value to dirty check against from the `__dataTemp` cache
+       * (rather than the normal `__data` cache) for Objects.  Since the temp
+       * cache is cleared at the end of a turn, this implementation allows
+       * side-effects of deep object changes to be processed by re-setting the
+       * same object (using the temp cache as an in-turn backstop to prevent
+       * cycles due to 2-way notification).
+       */
+      _shouldPropertyChange(property: string, value: any, old: any): boolean;
+    }
+  } & T
+}

--- a/src/test/goldens/polymer/lib/mixins/property-accessors.d.ts
+++ b/src/test/goldens/polymer/lib/mixins/property-accessors.d.ts
@@ -1,0 +1,221 @@
+declare namespace Polymer {
+
+  /**
+   * Element class mixin that provides basic meta-programming for creating one
+   * or more property accessors (getter/setter pair) that enqueue an async
+   * (batched) `_propertiesChanged` callback.
+   * 
+   * For basic usage of this mixin, simply declare attributes to observe via
+   * the standard `static get observedAttributes()`, implement `_propertiesChanged`
+   * on the class, and then call `MyClass.createPropertiesForAttributes()` once
+   * on the class to generate property accessors for each observed attribute
+   * prior to instancing. Last, call `this._enableProperties()` in the element's
+   * `connectedCallback` to enable the accessors.
+   * 
+   * Any `observedAttributes` will automatically be
+   * deserialized via `attributeChangedCallback` and set to the associated
+   * property using `dash-case`-to-`camelCase` convention.
+   */
+  function PropertyAccessors<T extends new(...args: any[]) => {}>(base: T): {
+    new(...args: any[]): {
+      __serializing: boolean;
+      __dataCounter: number;
+      __dataEnabled: boolean;
+      __dataReady: boolean;
+      __dataInvalid: boolean;
+      __data: Object;
+      __dataPending: Object|null;
+      __dataOld: Object|null;
+      __dataProto: Object|null;
+      __dataHasAccessor: Object|null;
+      __dataInstanceProps: Object|null;
+
+      /**
+       * Implements native Custom Elements `attributeChangedCallback` to
+       * set an attribute value to a property via `_attributeToProperty`.
+       */
+      attributeChangedCallback(name: string, old: string|null, value: string|null): any;
+
+      /**
+       * Initializes the local storage for property accessors.
+       * 
+       * Provided as an override point for performing any setup work prior
+       * to initializing the property accessor system.
+       */
+      _initializeProperties(): any;
+
+      /**
+       * Called at instance time with bag of properties that were overwritten
+       * by accessors on the prototype when accessors were created.
+       * 
+       * The default implementation sets these properties back into the
+       * setter at instance time.  This method is provided as an override
+       * point for customizing or providing more efficient initialization.
+       */
+      _initializeProtoProperties(props: Object|null): any;
+
+      /**
+       * Called at ready time with bag of instance properties that overwrote
+       * accessors when the element upgraded.
+       * 
+       * The default implementation sets these properties back into the
+       * setter at ready time.  This method is provided as an override
+       * point for customizing or providing more efficient initialization.
+       */
+      _initializeInstanceProperties(props: Object|null): any;
+
+      /**
+       * Ensures the element has the given attribute. If it does not,
+       * assigns the given value to the attribute.
+       */
+      _ensureAttribute(attribute: string, value: string): any;
+
+      /**
+       * Deserializes an attribute to its associated property.
+       * 
+       * This method calls the `_deserializeValue` method to convert the string to
+       * a typed value.
+       */
+      _attributeToProperty(attribute: string, value: string|null, type?: any): any;
+
+      /**
+       * Serializes a property to its associated attribute.
+       */
+      _propertyToAttribute(property: string, attribute?: string, value?: any): any;
+
+      /**
+       * Sets a typed value to an HTML attribute on a node.
+       * 
+       * This method calls the `_serializeValue` method to convert the typed
+       * value to a string.  If the `_serializeValue` method returns `undefined`,
+       * the attribute will be removed (this is the default for boolean
+       * type `false`).
+       */
+      _valueToNodeAttribute(node: Element|null, value: any, attribute: string): any;
+
+      /**
+       * Converts a typed JavaScript value to a string.
+       * 
+       * This method is called by Polymer when setting JS property values to
+       * HTML attributes.  Users may override this method on Polymer element
+       * prototypes to provide serialization for custom types.
+       */
+      _serializeValue(value: any): string|undefined;
+
+      /**
+       * Converts a string to a typed JavaScript value.
+       * 
+       * This method is called by Polymer when reading HTML attribute values to
+       * JS properties.  Users may override this method on Polymer element
+       * prototypes to provide deserialization for custom `type`s.  Note,
+       * the `type` argument is the value of the `type` field provided in the
+       * `properties` configuration object for a given property, and is
+       * by convention the constructor for the type to deserialize.
+       * 
+       * Note: The return value of `undefined` is used as a sentinel value to
+       * indicate the attribute should be removed.
+       */
+      _deserializeValue(value: string|null, type?: any): any;
+
+      /**
+       * Creates a setter/getter pair for the named property with its own
+       * local storage.  The getter returns the value in the local storage,
+       * and the setter calls `_setProperty`, which updates the local storage
+       * for the property and enqueues a `_propertiesChanged` callback.
+       * 
+       * This method may be called on a prototype or an instance.  Calling
+       * this method may overwrite a property value that already exists on
+       * the prototype/instance by creating the accessor.  When calling on
+       * a prototype, any overwritten values are saved in `__dataProto`,
+       * and it is up to the subclasser to decide how/when to set those
+       * properties back into the accessor.  When calling on an instance,
+       * the overwritten value is set via `_setPendingProperty`, and the
+       * user should call `_invalidateProperties` or `_flushProperties`
+       * for the values to take effect.
+       */
+      _createPropertyAccessor(property: string, readOnly?: boolean): any;
+
+      /**
+       * Returns true if this library created an accessor for the given property.
+       */
+      _hasAccessor(property: string): boolean;
+
+      /**
+       * Updates the local storage for a property (via `_setPendingProperty`)
+       * and enqueues a `_propertiesChanged` callback.
+       */
+      _setProperty(property: string, value: any): any;
+
+      /**
+       * Updates the local storage for a property, records the previous value,
+       * and adds it to the set of "pending changes" that will be passed to the
+       * `_propertiesChanged` callback.  This method does not enqueue the
+       * `_propertiesChanged` callback.
+       */
+      _setPendingProperty(property: string, value: any): boolean;
+
+      /**
+       * Returns true if the specified property has a pending change.
+       */
+      _isPropertyPending(prop: string): boolean;
+
+      /**
+       * Marks the properties as invalid, and enqueues an async
+       * `_propertiesChanged` callback.
+       */
+      _invalidateProperties(): any;
+
+      /**
+       * Call to enable property accessor processing. Before this method is
+       * called accessor values will be set but side effects are
+       * queued. When called, any pending side effects occur immediately.
+       * For elements, generally `connectedCallback` is a normal spot to do so.
+       * It is safe to call this method multiple times as it only turns on
+       * property accessors once.
+       */
+      _enableProperties(): any;
+
+      /**
+       * Calls the `_propertiesChanged` callback with the current set of
+       * pending changes (and old values recorded when pending changes were
+       * set), and resets the pending set of changes. Generally, this method
+       * should not be called in user code.
+       */
+      _flushProperties(): any;
+
+      /**
+       * Lifecycle callback called the first time properties are being flushed.
+       * Prior to `ready`, all property sets through accessors are queued and
+       * their effects are flushed after this method returns.
+       * 
+       * Users may override this function to implement behavior that is
+       * dependent on the element having its properties initialized, e.g.
+       * from defaults (initialized from `constructor`, `_initializeProperties`),
+       * `attributeChangedCallback`, or values propagated from host e.g. via
+       * bindings.  `super.ready()` must be called to ensure the data system
+       * becomes enabled.
+       */
+      ready(): any;
+
+      /**
+       * Callback called when any properties with accessors created via
+       * `_createPropertyAccessor` have been set.
+       */
+      _propertiesChanged(currentProps: Object, changedProps: Object, oldProps: Object): any;
+
+      /**
+       * Method called to determine whether a property value should be
+       * considered as a change and cause the `_propertiesChanged` callback
+       * to be enqueued.
+       * 
+       * The default implementation returns `true` for primitive types if a
+       * strict equality check fails, and returns `true` for all Object/Arrays.
+       * The method always returns false for `NaN`.
+       * 
+       * Override this method to e.g. provide stricter checking for
+       * Objects/Arrays when using immutable patterns.
+       */
+      _shouldPropertyChange(property: string, value: any, old: any): boolean;
+    }
+  } & T
+}

--- a/src/test/goldens/polymer/lib/mixins/property-effects.d.ts
+++ b/src/test/goldens/polymer/lib/mixins/property-effects.d.ts
@@ -1,0 +1,438 @@
+declare namespace Polymer {
+
+  /**
+   * Element class mixin that provides meta-programming for Polymer's template
+   * binding and data observation (collectively, "property effects") system.
+   * 
+   * This mixin uses provides the following key static methods for adding
+   * property effects to an element class:
+   * - `addPropertyEffect`
+   * - `createPropertyObserver`
+   * - `createMethodObserver`
+   * - `createNotifyingProperty`
+   * - `createReadOnlyProperty`
+   * - `createReflectedProperty`
+   * - `createComputedProperty`
+   * - `bindTemplate`
+   * 
+   * Each method creates one or more property accessors, along with metadata
+   * used by this mixin's implementation of `_propertiesChanged` to perform
+   * the property effects.
+   * 
+   * Underscored versions of the above methods also exist on the element
+   * prototype for adding property effects on instances at runtime.
+   * 
+   * Note that this mixin overrides several `PropertyAccessors` methods, in
+   * many cases to maintain guarantees provided by the Polymer 1.x features;
+   * notably it changes property accessors to be synchronous by default
+   * whereas the default when using `PropertyAccessors` standalone is to be
+   * async by default.
+   */
+  function PropertyEffects<T extends new(...args: any[]) => {}>(base: T): {
+    new(...args: any[]): {
+      __dataCounter: number;
+      __data: Object;
+      __dataPending: Object;
+      __dataOld: Object;
+      __dataClientsReady: boolean;
+      __dataPendingClients: any[]|null;
+      __dataToNotify: Object|null;
+      __dataLinkedPaths: Object|null;
+      __dataHasPaths: boolean;
+      __dataCompoundStorage: Object|null;
+      __dataHost: Polymer_PropertyEffects|null;
+      __dataTemp: Object;
+      __dataClientsInitialized: boolean;
+      __computeEffects: Object|null;
+      __reflectEffects: Object|null;
+      __notifyEffects: Object|null;
+      __propagateEffects: Object|null;
+      __observeEffects: Object|null;
+      __readOnly: Object|null;
+      __templateInfo: TemplateInfo;
+
+      /**
+       * Stamps the provided template and performs instance-time setup for
+       * Polymer template features, including data bindings, declarative event
+       * listeners, and the `this.$` map of `id`'s to nodes.  A document fragment
+       * is returned containing the stamped DOM, ready for insertion into the
+       * DOM.
+       * 
+       * This method may be called more than once; however note that due to
+       * `shadycss` polyfill limitations, only styles from templates prepared
+       * using `ShadyCSS.prepareTemplate` will be correctly polyfilled (scoped
+       * to the shadow root and support CSS custom properties), and note that
+       * `ShadyCSS.prepareTemplate` may only be called once per element. As such,
+       * any styles required by in runtime-stamped templates must be included
+       * in the main element template.
+       */
+      _stampTemplate(template: HTMLTemplateElement): StampedTemplate;
+      _initializeProperties(): any;
+
+      /**
+       * Overrides `Polymer.PropertyAccessors` implementation to provide a
+       * more efficient implementation of initializing properties from
+       * the prototype on the instance.
+       */
+      _initializeProtoProperties(props: Object|null): any;
+
+      /**
+       * Overrides `Polymer.PropertyAccessors` implementation to avoid setting
+       * `_setProperty`'s `shouldNotify: true`.
+       */
+      _initializeInstanceProperties(props: Object|null): any;
+
+      /**
+       * Overrides base implementation to ensure all accessors set `shouldNotify`
+       * to true, for per-property notification tracking.
+       */
+      _setProperty(property: any, value: any): any;
+
+      /**
+       * Overrides the `PropertyAccessors` implementation to introduce special
+       * dirty check logic depending on the property & value being set:
+       * 
+       * 1. Any value set to a path (e.g. 'obj.prop': 42 or 'obj.prop': {...})
+       *    Stored in `__dataTemp`, dirty checked against `__dataTemp`
+       * 2. Object set to simple property (e.g. 'prop': {...})
+       *    Stored in `__dataTemp` and `__data`, dirty checked against
+       *    `__dataTemp` by default implementation of `_shouldPropertyChange`
+       * 3. Primitive value set to simple property (e.g. 'prop': 42)
+       *    Stored in `__data`, dirty checked against `__data`
+       * 
+       * The dirty-check is important to prevent cycles due to two-way
+       * notification, but paths and objects are only dirty checked against any
+       * previous value set during this turn via a "temporary cache" that is
+       * cleared when the last `_propertiesChanged` exits. This is so:
+       * a. any cached array paths (e.g. 'array.3.prop') may be invalidated
+       *    due to array mutations like shift/unshift/splice; this is fine
+       *    since path changes are dirty-checked at user entry points like `set`
+       * b. dirty-checking for objects only lasts one turn to allow the user
+       *    to mutate the object in-place and re-set it with the same identity
+       *    and have all sub-properties re-propagated in a subsequent turn.
+       * 
+       * The temp cache is not necessarily sufficient to prevent invalid array
+       * paths, since a splice can happen during the same turn (with pathological
+       * user code); we could introduce a "fixup" for temporarily cached array
+       * paths if needed: https://github.com/Polymer/polymer/issues/4227
+       */
+      _setPendingProperty(property: string, value: any, shouldNotify?: boolean): boolean;
+
+      /**
+       * Overrides `PropertyAccessor`'s default async queuing of
+       * `_propertiesChanged`: if `__dataReady` is false (has not yet been
+       * manually flushed), the function no-ops; otherwise flushes
+       * `_propertiesChanged` synchronously.
+       */
+      _invalidateProperties(): any;
+
+      /**
+       * Overrides `PropertyAccessors` so that property accessor
+       * side effects are not enabled until after client dom is fully ready.
+       * Also calls `_flushClients` callback to ensure client dom is enabled
+       * that was not enabled as a result of flushing properties.
+       */
+      ready(): any;
+
+      /**
+       * Implements `PropertyAccessors`'s properties changed callback.
+       * 
+       * Runs each class of effects for the batch of changed properties in
+       * a specific order (compute, propagate, reflect, observe, notify).
+       */
+      _propertiesChanged(currentProps: any, changedProps: any, oldProps: any): any;
+
+      /**
+       * Equivalent to static `addPropertyEffect` API but can be called on
+       * an instance to add effects at runtime.  See that method for
+       * full API docs.
+       */
+      _addPropertyEffect(property: string, type: string, effect?: Object|null): any;
+
+      /**
+       * Removes the given property effect.
+       */
+      _removePropertyEffect(property: string, type: string, effect?: Object|null): any;
+
+      /**
+       * Returns whether the current prototype/instance has a property effect
+       * of a certain type.
+       */
+      _hasPropertyEffect(property: string, type?: string): boolean;
+
+      /**
+       * Returns whether the current prototype/instance has a "read only"
+       * accessor for the given property.
+       */
+      _hasReadOnlyEffect(property: string): boolean;
+
+      /**
+       * Returns whether the current prototype/instance has a "notify"
+       * property effect for the given property.
+       */
+      _hasNotifyEffect(property: string): boolean;
+
+      /**
+       * Returns whether the current prototype/instance has a "reflect to attribute"
+       * property effect for the given property.
+       */
+      _hasReflectEffect(property: string): boolean;
+
+      /**
+       * Returns whether the current prototype/instance has a "computed"
+       * property effect for the given property.
+       */
+      _hasComputedEffect(property: string): boolean;
+
+      /**
+       * Sets a pending property or path.  If the root property of the path in
+       * question had no accessor, the path is set, otherwise it is enqueued
+       * via `_setPendingProperty`.
+       * 
+       * This function isolates relatively expensive functionality necessary
+       * for the public API (`set`, `setProperties`, `notifyPath`, and property
+       * change listeners via {{...}} bindings), such that it is only done
+       * when paths enter the system, and not at every propagation step.  It
+       * also sets a `__dataHasPaths` flag on the instance which is used to
+       * fast-path slower path-matching code in the property effects host paths.
+       * 
+       * `path` can be a path string or array of path parts as accepted by the
+       * public API.
+       */
+      _setPendingPropertyOrPath(path: string|Array<number|string>, value: any, shouldNotify?: boolean, isPathNotification?: boolean): boolean;
+
+      /**
+       * Applies a value to a non-Polymer element/node's property.
+       * 
+       * The implementation makes a best-effort at binding interop:
+       * Some native element properties have side-effects when
+       * re-setting the same value (e.g. setting `<input>.value` resets the
+       * cursor position), so we do a dirty-check before setting the value.
+       * However, for better interop with non-Polymer custom elements that
+       * accept objects, we explicitly re-set object changes coming from the
+       * Polymer world (which may include deep object changes without the
+       * top reference changing), erring on the side of providing more
+       * information.
+       * 
+       * Users may override this method to provide alternate approaches.
+       */
+      _setUnmanagedPropertyToNode(node: Node|null, prop: string, value: any): any;
+
+      /**
+       * Enqueues the given client on a list of pending clients, whose
+       * pending property changes can later be flushed via a call to
+       * `_flushClients`.
+       */
+      _enqueueClient(client: Object|null): any;
+
+      /**
+       * Flushes any clients previously enqueued via `_enqueueClient`, causing
+       * their `_flushProperties` method to run.
+       */
+      _flushClients(): any;
+
+      /**
+       * (c) the stamped dom enables.
+       */
+      __enableOrFlushClients(): any;
+
+      /**
+       * Perform any initial setup on client dom. Called before the first
+       * `_flushProperties` call on client dom and before any element
+       * observers are called.
+       */
+      _readyClients(): any;
+
+      /**
+       * Sets a bag of property changes to this instance, and
+       * synchronously processes all effects of the properties as a batch.
+       * 
+       * Property names must be simple properties, not paths.  Batched
+       * path propagation is not supported.
+       */
+      setProperties(props: Object|null, setReadOnly?: boolean): any;
+
+      /**
+       * Called to propagate any property changes to stamped template nodes
+       * managed by this element.
+       */
+      _propagatePropertyChanges(changedProps: Object|null, oldProps: Object|null, hasPaths: boolean): any;
+
+      /**
+       * Aliases one data path as another, such that path notifications from one
+       * are routed to the other.
+       */
+      linkPaths(to: string|Array<string|number>, from: string|Array<string|number>): any;
+
+      /**
+       * Removes a data path alias previously established with `_linkPaths`.
+       * 
+       * Note, the path to unlink should be the target (`to`) used when
+       * linking the paths.
+       */
+      unlinkPaths(path: string|Array<string|number>): any;
+
+      /**
+       * Notify that an array has changed.
+       * 
+       * Example:
+       * 
+       *     this.items = [ {name: 'Jim'}, {name: 'Todd'}, {name: 'Bill'} ];
+       *     ...
+       *     this.items.splice(1, 1, {name: 'Sam'});
+       *     this.items.push({name: 'Bob'});
+       *     this.notifySplices('items', [
+       *       { index: 1, removed: [{name: 'Todd'}], addedCount: 1, object: this.items, type: 'splice' },
+       *       { index: 3, removed: [], addedCount: 1, object: this.items, type: 'splice'}
+       *     ]);
+       */
+      notifySplices(path: string, splices: any[]|null): any;
+
+      /**
+       * Convenience method for reading a value from a path.
+       * 
+       * Note, if any part in the path is undefined, this method returns
+       * `undefined` (this method does not throw when dereferencing undefined
+       * paths).
+       */
+      get(path: string|Array<string|number>, root?: Object|null): any;
+
+      /**
+       * Convenience method for setting a value to a path and notifying any
+       * elements bound to the same path.
+       * 
+       * Note, if any part in the path except for the last is undefined,
+       * this method does nothing (this method does not throw when
+       * dereferencing undefined paths).
+       */
+      set(path: string|Array<string|number>, value: any, root?: Object|null): any;
+
+      /**
+       * Adds items onto the end of the array at the path specified.
+       * 
+       * The arguments after `path` and return value match that of
+       * `Array.prototype.push`.
+       * 
+       * This method notifies other paths to the same array that a
+       * splice occurred to the array.
+       */
+      push(path: string|Array<string|number>, ...items: any): number;
+
+      /**
+       * Removes an item from the end of array at the path specified.
+       * 
+       * The arguments after `path` and return value match that of
+       * `Array.prototype.pop`.
+       * 
+       * This method notifies other paths to the same array that a
+       * splice occurred to the array.
+       */
+      pop(path: string|Array<string|number>): any;
+
+      /**
+       * Starting from the start index specified, removes 0 or more items
+       * from the array and inserts 0 or more new items in their place.
+       * 
+       * The arguments after `path` and return value match that of
+       * `Array.prototype.splice`.
+       * 
+       * This method notifies other paths to the same array that a
+       * splice occurred to the array.
+       */
+      splice(path: string|Array<string|number>, start: number, deleteCount: number, ...items: any): any[]|null;
+
+      /**
+       * Removes an item from the beginning of array at the path specified.
+       * 
+       * The arguments after `path` and return value match that of
+       * `Array.prototype.pop`.
+       * 
+       * This method notifies other paths to the same array that a
+       * splice occurred to the array.
+       */
+      shift(path: string|Array<string|number>): any;
+
+      /**
+       * Adds items onto the beginning of the array at the path specified.
+       * 
+       * The arguments after `path` and return value match that of
+       * `Array.prototype.push`.
+       * 
+       * This method notifies other paths to the same array that a
+       * splice occurred to the array.
+       */
+      unshift(path: string|Array<string|number>, ...items: any): number;
+
+      /**
+       * Notify that a path has changed.
+       * 
+       * Example:
+       * 
+       *     this.item.user.name = 'Bob';
+       *     this.notifyPath('item.user.name');
+       */
+      notifyPath(path: string, value?: any): any;
+
+      /**
+       * Equivalent to static `createReadOnlyProperty` API but can be called on
+       * an instance to add effects at runtime.  See that method for
+       * full API docs.
+       */
+      _createReadOnlyProperty(property: string, protectedSetter?: boolean): any;
+
+      /**
+       * Equivalent to static `createPropertyObserver` API but can be called on
+       * an instance to add effects at runtime.  See that method for
+       * full API docs.
+       */
+      _createPropertyObserver(property: string, methodName: string, dynamicFn?: boolean): any;
+
+      /**
+       * Equivalent to static `createMethodObserver` API but can be called on
+       * an instance to add effects at runtime.  See that method for
+       * full API docs.
+       */
+      _createMethodObserver(expression: string, dynamicFn?: boolean|Object|null): any;
+
+      /**
+       * Equivalent to static `createNotifyingProperty` API but can be called on
+       * an instance to add effects at runtime.  See that method for
+       * full API docs.
+       */
+      _createNotifyingProperty(property: string): any;
+
+      /**
+       * Equivalent to static `createReflectedProperty` API but can be called on
+       * an instance to add effects at runtime.  See that method for
+       * full API docs.
+       */
+      _createReflectedProperty(property: string): any;
+
+      /**
+       * Equivalent to static `createComputedProperty` API but can be called on
+       * an instance to add effects at runtime.  See that method for
+       * full API docs.
+       */
+      _createComputedProperty(property: string, expression: string, dynamicFn?: boolean|Object|null): any;
+
+      /**
+       * Equivalent to static `bindTemplate` API but can be called on
+       * an instance to add effects at runtime.  See that method for
+       * full API docs.
+       * 
+       * This method may be called on the prototype (for prototypical template
+       * binding, to avoid creating accessors every instance) once per prototype,
+       * and will be called with `runtimeBinding: true` by `_stampTemplate` to
+       * create and link an instance of the template metadata associated with a
+       * particular stamping.
+       */
+      _bindTemplate(template: HTMLTemplateElement|null, instanceBinding?: boolean): TemplateInfo;
+
+      /**
+       * Removes and unbinds the nodes previously contained in the provided
+       * DocumentFragment returned from `_stampTemplate`.
+       */
+      _removeBoundDom(dom: StampedTemplate): any;
+    }
+  } & T
+}

--- a/src/test/goldens/polymer/lib/mixins/template-stamp.d.ts
+++ b/src/test/goldens/polymer/lib/mixins/template-stamp.d.ts
@@ -1,0 +1,55 @@
+declare namespace Polymer {
+
+  /**
+   * Element mixin that provides basic template parsing and stamping, including
+   * the following template-related features for stamped templates:
+   * 
+   * - Declarative event listeners (`on-eventname="listener"`)
+   * - Map of node id's to stamped node instances (`this.$.id`)
+   * - Nested template content caching/removal and re-installation (performance
+   *   optimization)
+   */
+  function TemplateStamp<T extends new(...args: any[]) => {}>(base: T): {
+    new(...args: any[]): {
+
+      /**
+       * Clones the provided template content and returns a document fragment
+       * containing the cloned dom.
+       * 
+       * The template is parsed (once and memoized) using this library's
+       * template parsing features, and provides the following value-added
+       * features:
+       * * Adds declarative event listeners for `on-event="handler"` attributes
+       * * Generates an "id map" for all nodes with id's under `$` on returned
+       *   document fragment
+       * * Passes template info including `content` back to templates as
+       *   `_templateInfo` (a performance optimization to avoid deep template
+       *   cloning)
+       * 
+       * Note that the memoized template parsing process is destructive to the
+       * template: attributes for bindings and declarative event listeners are
+       * removed after being noted in notes, and any nested `<template>.content`
+       * is removed and stored in notes as well.
+       */
+      _stampTemplate(template: HTMLTemplateElement): StampedTemplate;
+
+      /**
+       * Adds an event listener by method name for the event provided.
+       * 
+       * This method generates a handler function that looks up the method
+       * name at handling time.
+       */
+      _addMethodEventListenerToNode(node: Node|null, eventName: string, methodName: string, context?: any): Function|null;
+
+      /**
+       * Override point for adding custom or simulated event handling.
+       */
+      _addEventListenerToNode(node: Node|null, eventName: string, handler: Function|null): any;
+
+      /**
+       * Override point for adding custom or simulated event handling.
+       */
+      _removeEventListenerFromNode(node: Node|null, eventName: string, handler: Function|null): any;
+    }
+  } & T
+}

--- a/src/test/goldens/polymer/lib/utils/templatize.d.ts
+++ b/src/test/goldens/polymer/lib/utils/templatize.d.ts
@@ -1,4 +1,6 @@
-interface TemplateInstanceBase extends Polymer.Element {
+declare class TemplateInstanceBase extends
+  Polymer.PropertyEffects(
+  Polymer.Element) {
   _addEventListenerToNode(node: any, eventName: any, handler: any): any;
 
   /**

--- a/src/test/goldens/polymer/polymer-element.d.ts
+++ b/src/test/goldens/polymer/polymer-element.d.ts
@@ -5,6 +5,8 @@ declare namespace Polymer {
    * features including template stamping, data-binding, attribute deserialization,
    * and property change observation.
    */
-  interface Element extends Polymer.Element {
+  class Element extends
+    Polymer.ElementMixin(
+    HTMLElement) {
   }
 }

--- a/src/test/serialize_test.ts
+++ b/src/test/serialize_test.ts
@@ -121,6 +121,7 @@ interface MyInterface extends MyBase1, MyBase2 {
       name: 'MyClass',
       description: 'Description of MyClass.',
       extends: 'MyBase',
+      mixins: [],
       properties: [
         {
           kind: 'property',
@@ -164,6 +165,32 @@ declare class MyClass extends MyBase {
 `);
   });
 
+  test('class mixins', () => {
+    const c: Class = {
+      kind: 'class',
+      name: 'MyClass',
+      description: '',
+      extends: 'MyBase',
+      mixins: ['Mixin1', 'Mixin2'],
+      properties: [
+        {
+          kind: 'property',
+          name: 'myProperty',
+          description: '',
+          type: {kind: 'name', name: 'string'},
+        },
+      ],
+      methods: [],
+    };
+    assert.equal(serializeTsDeclarations(c), `declare class MyClass extends
+  Mixin1(
+  Mixin2(
+  MyBase)) {
+  myProperty: string;
+}
+`);
+  });
+
   test('document', () => {
     assert.equal(
         serializeTsDeclarations({
@@ -183,6 +210,7 @@ declare class MyClass extends MyBase {
               name: 'MyClass',
               description: '',
               extends: '',
+              mixins: [],
               properties: [],
               methods: []
             },

--- a/src/ts-ast.ts
+++ b/src/ts-ast.ts
@@ -12,13 +12,13 @@
 export interface Document {
   kind: 'document';
   path: string;
-  members: Array<Namespace|Class|Interface|Function>;
+  members: Array<Namespace|Class|Interface|Mixin|Function>;
 }
 
 export interface Namespace {
   kind: 'namespace';
   name: string;
-  members: Array<Namespace|Class|Interface|Function>;
+  members: Array<Namespace|Class|Interface|Mixin|Function>;
 }
 
 export interface Class {
@@ -35,6 +35,16 @@ export interface Interface {
   name: string;
   description: string;
   extends: string[];
+  properties: Property[];
+  methods: Method[];
+}
+
+// A class mixin using the pattern described at:
+// https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html
+export interface Mixin {
+  kind: 'mixin';
+  name: string;
+  description: string;
   properties: Property[];
   methods: Method[];
 }

--- a/src/ts-ast.ts
+++ b/src/ts-ast.ts
@@ -26,6 +26,7 @@ export interface Class {
   name: string;
   description: string;
   extends: string;
+  mixins: string[];
   properties: Property[];
   methods: Method[];
 }

--- a/src/ts-serialize.ts
+++ b/src/ts-serialize.ts
@@ -17,8 +17,8 @@ import * as ts from './ts-ast';
  * Serialize a TypeScript declarations file AST to a string.
  */
 export function serializeTsDeclarations(
-    node: ts.Document|ts.Namespace|ts.Class|ts.Interface|ts.Function|
-    ts.Property,
+    node: (ts.Document|ts.Namespace|ts.Class|ts.Interface|ts.Mixin|
+           ts.Function|ts.Property),
     depth: number = 0): string {
   switch (node.kind) {
     case 'document':
@@ -29,6 +29,8 @@ export function serializeTsDeclarations(
       return serializeClass(node, depth);
     case 'interface':
       return serializeInterface(node, depth);
+    case 'mixin':
+      return serializeMixin(node, depth);
     case 'function':
       return serializeFunctionOrMethod(node, depth);
     case 'property':
@@ -145,6 +147,31 @@ function serializeInterface(node: ts.Interface, depth: number): string {
     out += '\n';
   }
   out += `${i}}\n`;
+  return out;
+}
+
+function serializeMixin(node: ts.Mixin, depth: number): string {
+  let out = '';
+  const i = indent(depth);
+  const i2 = indent(depth + 1);
+  if (node.description) {
+    out += formatComment(node.description, depth);
+  }
+  out += i;
+  if (depth === 0) {
+    out += 'declare ';
+  }
+  out += `function ${node.name}`;
+  out += `<T extends new(...args: any[]) => {}>(base: T): {\n`;
+  out += `${i2}new(...args: any[]): {\n`;
+  for (const property of node.properties) {
+    out += serializeProperty(property, depth + 2);
+  }
+  for (const method of node.methods) {
+    out += serializeFunctionOrMethod(method, depth + 2);
+  }
+  out += `${i2}}\n`;
+  out += `${i}} & T\n`;
   return out;
 }
 

--- a/src/ts-serialize.ts
+++ b/src/ts-serialize.ts
@@ -97,7 +97,7 @@ function serializeNamespace(node: ts.Namespace, depth: number): string {
   return out;
 }
 
-function serializeClass(node: ts.Class|ts.Interface, depth: number): string {
+function serializeClass(node: ts.Class, depth: number): string {
   let out = '';
   const i = indent(depth);
   if (node.description) {

--- a/src/ts-serialize.ts
+++ b/src/ts-serialize.ts
@@ -108,9 +108,20 @@ function serializeClass(node: ts.Class, depth: number): string {
     out += 'declare ';
   }
   out += `class ${node.name}`;
-  if (node.extends) {
+
+  if (node.mixins.length) {
+    const i2 = indent(depth + 1);
+    out += ' extends';
+    for (const mixin of node.mixins) {
+      out += `\n${i2}${mixin}(`;
+    }
+    out += `\n${i2}${node.extends || 'Object'}`;
+    out += ')'.repeat(node.mixins.length)
+
+  } else if (node.extends) {
     out += ' extends ' + node.extends;
   }
+
   out += ' {\n';
   for (const property of node.properties) {
     out += serializeProperty(property, depth + 1);


### PR DESCRIPTION
- Generate mixins using the style documented at https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html.
- Write out class-based elements as classes, instead of as interfaces.
- Class-based elements extend `All(Their(Mixins))`.