### PR TITLE
Simplify union types. Gets rid of `foo|null|bar|null` type mess.

### DIFF
--- a/src/closure-types.ts
+++ b/src/closure-types.ts
@@ -142,10 +142,6 @@ function convertArray(node: doctrine.type.TypeApplication): ts.Type {
 }
 
 function convertUnion(node: doctrine.type.UnionType): ts.Type {
-  if (node.elements.length === 1) {
-    // `(string)` will be represented as a union of length one. Just flatten.
-    return convert(node.elements[0]);
-  }
   return new ts.UnionType(node.elements.map(convert));
 }
 

--- a/src/gen-ts.ts
+++ b/src/gen-ts.ts
@@ -65,6 +65,7 @@ function analyzerToAst(analysis: analyzer.Analysis): ts.Document[] {
     for (const analyzerDoc of analyzerDocs) {
       handleDocument(analyzerDoc, tsDoc);
     }
+    tsDoc.simplify();
     if (tsDoc.members.length) {
       tsDocs.push(tsDoc);
     }

--- a/src/test/goldens/polymer/lib/elements/array-selector.d.ts
+++ b/src/test/goldens/polymer/lib/elements/array-selector.d.ts
@@ -98,7 +98,7 @@ declare namespace Polymer {
        * When `multi` is false, this is the currently selected item, or `null`
        * if no item is selected.
        */
-      selected: Object|null|Object[]|null|null;
+      selected: Object|null|Object[];
 
       /**
        * When `multi` is false, this is the currently selected item, or `null`

--- a/src/test/goldens/polymer/lib/legacy/class.d.ts
+++ b/src/test/goldens/polymer/lib/legacy/class.d.ts
@@ -8,7 +8,7 @@ declare namespace Polymer {
    * to ensure that any legacy behaviors can rely on legacy Polymer API on
    * the underlying element.
    */
-  function mixinBehaviors(behaviors: Object|null|any[]|null, klass: HTMLElement|(() => any)): () => any;
+  function mixinBehaviors(behaviors: Object|null|any[], klass: HTMLElement|(() => any)): () => any;
 
 
   /**

--- a/src/test/goldens/polymer/lib/legacy/polymer.dom.d.ts
+++ b/src/test/goldens/polymer/lib/legacy/polymer.dom.d.ts
@@ -19,5 +19,5 @@ declare namespace Polymer {
    * in the majority of cases simply facades directly to the standard native
    * API.
    */
-  function dom(obj: Node|Event|null): DomApi|null|EventApi|null;
+  function dom(obj: Node|Event|null): DomApi|null|EventApi;
 }

--- a/src/test/goldens/polymer/lib/mixins/element-mixin.d.ts
+++ b/src/test/goldens/polymer/lib/mixins/element-mixin.d.ts
@@ -62,7 +62,7 @@ declare namespace Polymer {
       _importPath: string;
       rootPath: string;
       importPath: string;
-      root: StampedTemplate|null|HTMLElement|null|ShadowRoot|null;
+      root: StampedTemplate|null|HTMLElement|ShadowRoot;
       $: any;
 
       /**


### PR DESCRIPTION
This builds on the class refactor.

Nodes now have a `walk` method which traverses the whole AST depth first. We look for all the union types, and simplify them.

We simplify a union by 1) flattening it (`foo|(bar|baz)` -> `foo|bar|baz`) and 2) de-duping it (`foo|null|bar|null` -> `foo|null|bar`). This pattern comes up a lot because you have Closure signatures like `Array|Object` which turn into `(Array|null)|(Object|null)`.