### PR TITLE
Handle method parameters with defaults correctly.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /node_modules
 /lib
-/src/test/fixtures
+
+# All of the test fixtures are generated on install, except for "custom".
+/src/test/fixtures/*
+!/src/test/fixtures/custom

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,9 +99,9 @@
       }
     },
     "acorn": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+      "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
     },
     "acorn-jsx": {
       "version": "3.0.1",
@@ -461,7 +461,7 @@
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
       "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
       "requires": {
-        "acorn": "5.1.2",
+        "acorn": "5.2.1",
         "acorn-jsx": "3.0.1"
       }
     },
@@ -2036,9 +2036,9 @@
       "dev": true
     },
     "polymer-analyzer": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-2.3.0.tgz",
-      "integrity": "sha512-mgvLJ7hez52/Iy54GGFVRs9CoO0jXWeS2Iqows5GJpL+KnFiR1afziI2s/5teQcC53vtPUtWba8PEeQHroD5Hw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-2.5.0.tgz",
+      "integrity": "sha512-rZS1ZzCPInuOKbTbAMUIKNo9c95fi7KLEQFFDRavafCuyiB9Fi2KIkKdrgb9KqBDJAIGoShM0lYVzGJiB/+5hQ==",
       "requires": {
         "@types/chai-subset": "1.3.1",
         "@types/chalk": "0.4.31",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2036,9 +2036,9 @@
       "dev": true
     },
     "polymer-analyzer": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-2.5.0.tgz",
-      "integrity": "sha512-rZS1ZzCPInuOKbTbAMUIKNo9c95fi7KLEQFFDRavafCuyiB9Fi2KIkKdrgb9KqBDJAIGoShM0lYVzGJiB/+5hQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-2.6.0.tgz",
+      "integrity": "sha512-UXwVND8V17tN2Td8M4GRFbbPHzQjusPNaF4Q8798OQ9gaamoRiYqn5iQ6sFY0yI8EnlhUMagNp5/ejEfBD3HnQ==",
       "requires": {
         "@types/chai-subset": "1.3.1",
         "@types/chalk": "0.4.31",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "doctrine": "^2.0.0",
     "escodegen": "^1.9.0",
     "fs-extra": "^4.0.2",
-    "polymer-analyzer": "^2.5.0"
+    "polymer-analyzer": "^2.6.0"
   },
   "devDependencies": {
     "@types/chai": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -39,10 +39,9 @@
     "format": "find src -name '*.ts' -not -path 'src/test/fixtures/*' -not -path 'src/test/goldens/*' | xargs clang-format --style=file -i",
     "build": "npm run clean && tsc",
     "build:watch": "tsc --watch",
-    "test": "npm run test:setup-once && npm run build && mocha",
+    "test": "npm run test:setup && npm run build && mocha",
     "test:watch": "watchy -w src -- npm run test",
     "test:setup": "scripts/setup-fixtures.sh",
-    "test:setup-once": "mkdir src/test/fixtures && npm run test:setup || true",
     "test:make-goldens": "npm run build && scripts/make-goldens.js"
   },
   "repository": {

--- a/scripts/make-goldens.js
+++ b/scripts/make-goldens.js
@@ -28,7 +28,7 @@ const {generateDeclarations} = require('../lib/gen-ts');
 const fixturesDir = path.join(__dirname, '..', 'src', 'test', 'fixtures');
 const goldensDir = path.join(__dirname, '..', 'src', 'test', 'goldens');
 
-fsExtra.emptyDir(goldensDir);
+fsExtra.emptyDirSync(goldensDir);
 
 for (const fixture of fs.readdirSync(fixturesDir)) {
   console.log('making goldens for ' + fixture);

--- a/scripts/setup-fixtures.sh
+++ b/scripts/setup-fixtures.sh
@@ -18,11 +18,11 @@
 set -e
 
 cd src/test
-rm -rf fixtures
-mkdir fixtures
+mkdir -p fixtures
 cd fixtures
 
 while read -r repo tag dir; do
+  if [ -d $dir ]; then continue; fi  # Already set up.
   git clone $repo $dir
   cd $dir
   git checkout $tag

--- a/src/gen-ts.ts
+++ b/src/gen-ts.ts
@@ -249,6 +249,8 @@ function handleFunction(feature: AnalyzerFunction, root: ts.Document) {
   });
 
   for (const param of feature.params || []) {
+    // TODO Handle parameter default values. Requires support from Analyzer
+    // which only handles this for class method parameters currently.
     const {type, optional, rest} = closureParamToTypeScript(param.type);
     f.params.push(new ts.Param({name: param.name, type, optional, rest}));
   }
@@ -297,14 +299,37 @@ function handleMethods(analyzerMethods: Iterable<analyzer.Method>):
     });
     m.description = method.description || '';
 
-    for (const param of method.params || []) {
-      const {type, optional, rest} = closureParamToTypeScript(param.type);
-      m.params.push(new ts.Param({name: param.name, type, optional, rest}));
+    let requiredAhead = false;
+    for (const param of reverseIter(method.params || [])) {
+      let {type, optional, rest} = closureParamToTypeScript(param.type);
+      if (param.defaultValue !== undefined) {
+        // Parameters with default values generally behave like optional
+        // parameters. However, unlike optional parameters, they may be
+        // followed by a required parameter, in which case the default value is
+        // set by explicitly passing undefined.
+        if (!requiredAhead) {
+          optional = true;
+        } else {
+          type = new ts.UnionType([type, ts.undefinedType]);
+        }
+      } else if (!optional) {
+        requiredAhead = true;
+      }
+      m.params.unshift(new ts.Param({name: param.name, type, optional, rest}));
     }
 
     tsMethods.push(m);
   }
   return tsMethods;
+}
+
+/**
+ * Iterate over an array backwards.
+ */
+function* reverseIter<T>(arr: T[]) {
+  for (let i = arr.length - 1; i >= 0; i--) {
+    yield arr[i];
+  }
 }
 
 /**

--- a/src/gen-ts.ts
+++ b/src/gen-ts.ts
@@ -302,6 +302,7 @@ function handleMethods(analyzerMethods: Iterable<analyzer.Method>):
     let requiredAhead = false;
     for (const param of reverseIter(method.params || [])) {
       let {type, optional, rest} = closureParamToTypeScript(param.type);
+
       if (param.defaultValue !== undefined) {
         // Parameters with default values generally behave like optional
         // parameters. However, unlike optional parameters, they may be
@@ -315,6 +316,16 @@ function handleMethods(analyzerMethods: Iterable<analyzer.Method>):
       } else if (!optional) {
         requiredAhead = true;
       }
+
+      // Analyzer might know this is a rest parameter even if there was no
+      // JSDoc type annotation (or if it was wrong).
+      rest = rest || !!param.rest;
+      if (rest && type.kind !== 'array') {
+        // Closure rest parameter types are written without the Array syntax,
+        // but in TypeScript they must be explicitly arrays.
+        type = new ts.ArrayType(type);
+      }
+
       m.params.unshift(new ts.Param({name: param.name, type, optional, rest}));
     }
 

--- a/src/test/fixtures/custom/my-class.js
+++ b/src/test/fixtures/custom/my-class.js
@@ -31,4 +31,13 @@ class MyClass {
    * @param {string=} p2
    */
   required_and_optional_param(p1, p2) { }
+
+  defaulted_param(p1 = "foo") { }
+
+  /**
+   * @param {string=} p2
+   */
+  defaulted_and_optional_param(p1 = "foo", p2) { }
+
+  defaulted_and_required_param(p1 = "foo", p2) { }
 }

--- a/src/test/fixtures/custom/my-class.js
+++ b/src/test/fixtures/custom/my-class.js
@@ -22,6 +22,8 @@ class MyClass {
    */
   typed_rest_param(...p1) { }
 
+  undocumented_rest_param(...p1) { }
+
   /**
    * @param {string=} p1
    */

--- a/src/test/fixtures/custom/my-class.js
+++ b/src/test/fixtures/custom/my-class.js
@@ -1,0 +1,34 @@
+class MyClass {
+  no_params() { }
+
+  one_param(p1) { }
+
+  two_params(p1, p2) { }
+
+  /**
+   * @return {boolean}
+   */
+  typed_return() { }
+
+  /**
+   * @param {string} p1
+   * @param {number} p2
+   * @return {boolean}
+   */
+  two_typed_params_and_typed_return(p1, p2) { }
+
+  /**
+   * @param {...string} p1
+   */
+  typed_rest_param(...p1) { }
+
+  /**
+   * @param {string=} p1
+   */
+  optional_param(p1) { }
+
+  /**
+   * @param {string=} p2
+   */
+  required_and_optional_param(p1, p2) { }
+}

--- a/src/test/goldens/custom/my-class.d.ts
+++ b/src/test/goldens/custom/my-class.d.ts
@@ -5,6 +5,7 @@ declare class MyClass {
   typed_return(): boolean;
   two_typed_params_and_typed_return(p1: string, p2: number): boolean;
   typed_rest_param(...p1: string[]): any;
+  undocumented_rest_param(...p1: any[]): any;
   optional_param(p1?: string): any;
   required_and_optional_param(p1: any, p2?: string): any;
   defaulted_param(p1?: any): any;

--- a/src/test/goldens/custom/my-class.d.ts
+++ b/src/test/goldens/custom/my-class.d.ts
@@ -1,0 +1,10 @@
+declare class MyClass {
+  no_params(): any;
+  one_param(p1: any): any;
+  two_params(p1: any, p2: any): any;
+  typed_return(): boolean;
+  two_typed_params_and_typed_return(p1: string, p2: number): boolean;
+  typed_rest_param(...p1: string[]): any;
+  optional_param(p1?: string): any;
+  required_and_optional_param(p1: any, p2?: string): any;
+}

--- a/src/test/goldens/custom/my-class.d.ts
+++ b/src/test/goldens/custom/my-class.d.ts
@@ -7,4 +7,7 @@ declare class MyClass {
   typed_rest_param(...p1: string[]): any;
   optional_param(p1?: string): any;
   required_and_optional_param(p1: any, p2?: string): any;
+  defaulted_param(p1?: any): any;
+  defaulted_and_optional_param(p1?: any, p2?: string): any;
+  defaulted_and_required_param(p1: any|undefined, p2: any): any;
 }

--- a/src/test/goldens/polymer/lib/elements/dom-repeat.d.ts
+++ b/src/test/goldens/polymer/lib/elements/dom-repeat.d.ts
@@ -201,7 +201,7 @@ declare namespace Polymer {
     __observeChanged(): any;
     __itemsChanged(change: any): any;
     __handleObservedPaths(path: any): any;
-    __debounceRender(fn: () => any, delay = 0: any): any;
+    __debounceRender(fn: () => any, delay?: number): any;
 
     /**
      * Forces the element to render its content. Normally rendering is


### PR DESCRIPTION
Also:
- Add a "custom" test fixture to manually add coverage for specific cases.
- Output rest method parameter even when it has no JSDoc type.
