### PR TITLE
Add augment option

### DIFF
--- a/scripts/fixtures.txt
+++ b/scripts/fixtures.txt
@@ -1,3 +1,3 @@
 https://github.com/PolymerElements/paper-button.git v2.0.0 paper-button
 https://github.com/PolymerElements/paper-behaviors.git v2.0.1 paper-behaviors
-https://github.com/Polymer/polymer.git b124b707b497f1e592db7d85c5e64893402641b8 polymer
+https://github.com/Polymer/polymer.git aomarks-typescript polymer

--- a/scripts/setup-fixtures.sh
+++ b/scripts/setup-fixtures.sh
@@ -29,19 +29,3 @@ while read -r repo tag dir; do
   bower install
   cd -
 done < ../../../scripts/fixtures.txt
-
-# TODO Remove this hack once the config file is checked into the Polymer repo.
-# We want to test Polymer with a config file, but it's not checked in yet, and
-# we also can't clone into a directory unless it's empty. Just make the config
-# file here for now.
-cat > polymer/gen-tsd.json <<EOF
-{
-  "exclude": [
-    "dist/",
-    "externs/",
-    "gulpfile.js",
-    "test/",
-    "util/"
-  ]
-}
-EOF

--- a/src/test/goldens/polymer/lib/mixins/property-effects.d.ts
+++ b/src/test/goldens/polymer/lib/mixins/property-effects.d.ts
@@ -539,11 +539,11 @@ declare namespace Polymer {
      * full API docs.
      *
      * @param property Property name
-     * @param methodName Name of observer method to call
+     * @param method Function or name of observer method to call
      * @param dynamicFn Whether the method name should be included as
      *   a dependency to the effect.
      */
-    _createPropertyObserver(property: string, methodName: string, dynamicFn?: boolean): void|null;
+    _createPropertyObserver(property: string, method: string|((p0: any, p1: any) => any), dynamicFn?: boolean): void|null;
 
     /**
      * Equivalent to static `createMethodObserver` API but can be called on

--- a/src/test/goldens/polymer/lib/utils/boot.d.ts
+++ b/src/test/goldens/polymer/lib/utils/boot.d.ts
@@ -8,5 +8,7 @@
  *   lib/utils/boot.html
  */
 
+/// <reference path="../../augment-types.d.ts" />
+
 declare namespace Polymer {
 }


### PR DESCRIPTION
Add `augment` option to insert additional declaration references.

This lets us include manually defined typings for the cases that can't currently be automatically generated. FYI the manual typings are pushed to the Polymer PR @ https://github.com/Polymer/polymer/pull/4928/commits/8dccc9a072eff74252c7db665007a60815723630.

Also test Polymer using the `aomarks-typescript` branch, to iterate faster.

Part of https://github.com/Polymer/gen-typescript-declarations/issues/23