### PR TITLE
Exclude @private things.

### DIFF
--- a/src/gen-ts.ts
+++ b/src/gen-ts.ts
@@ -126,12 +126,19 @@ To modify these typings, edit the source file(s):
 ${sourceUrls.map((url) => '  ' + url).join('\n')}`;
 }
 
+interface MaybePrivate {
+  privacy?: 'public'|'private'|'protected'
+}
+
 /**
  * Extend the given TypeScript declarations document with all of the relevant
  * items in the given Polymer Analyzer document.
  */
 function handleDocument(doc: analyzer.Document, root: ts.Document) {
   for (const feature of doc.getFeatures()) {
+    if ((feature as MaybePrivate).privacy === 'private') {
+      continue;
+    }
     if (feature.kinds.has('element')) {
       handleElement(feature as analyzer.Element, root);
     } else if (feature.kinds.has('behavior')) {
@@ -323,7 +330,7 @@ function handleProperties(analyzerProperties: Iterable<analyzer.Property>):
     ts.Property[] {
   const tsProperties = <ts.Property[]>[];
   for (const property of analyzerProperties) {
-    if (property.inheritedFrom) {
+    if (property.inheritedFrom || property.privacy === 'private') {
       continue;
     }
     const p = new ts.Property({
@@ -347,7 +354,7 @@ function handleMethods(analyzerMethods: Iterable<analyzer.Method>):
     ts.Method[] {
   const tsMethods = <ts.Method[]>[];
   for (const method of analyzerMethods) {
-    if (method.inheritedFrom) {
+    if (method.inheritedFrom || method.privacy === 'private') {
       continue;
     }
     const m = new ts.Method({

--- a/src/test/goldens/polymer/lib/elements/array-selector.d.ts
+++ b/src/test/goldens/polymer/lib/elements/array-selector.d.ts
@@ -64,9 +64,6 @@ declare namespace Polymer {
      * will deselect the item.
      */
     toggle: boolean;
-    __updateSelection(multi: any, itemsInfo: any): any;
-    __applySplices(splices: any): any;
-    __updateLinks(): any;
 
     /**
      * Clears the selection state.
@@ -88,8 +85,6 @@ declare namespace Polymer {
      * @returns Whether the item is selected
      */
     isIndexSelected(idx: number): boolean;
-    __deselectChangedIdx(idx: any): any;
-    __selectedIndexForItemIndex(idx: any): any;
 
     /**
      * Deselects the given item if it is already selected.

--- a/src/test/goldens/polymer/lib/elements/dom-bind.d.ts
+++ b/src/test/goldens/polymer/lib/elements/dom-bind.d.ts
@@ -37,8 +37,6 @@ declare namespace Polymer {
     attributeChangedCallback(): any;
     connectedCallback(): any;
     disconnectedCallback(): any;
-    __insertChildren(): any;
-    __removeChildren(): any;
 
     /**
      * Forces the element to render its content. This is typically only

--- a/src/test/goldens/polymer/lib/elements/dom-if.d.ts
+++ b/src/test/goldens/polymer/lib/elements/dom-if.d.ts
@@ -47,7 +47,6 @@ declare namespace Polymer {
     restamp: boolean;
     connectedCallback(): any;
     disconnectedCallback(): any;
-    __debounceRender(): any;
 
     /**
      * Forces the element to render its content. Normally rendering is
@@ -57,10 +56,6 @@ declare namespace Polymer {
      * validate application state.
      */
     render(): void|null;
-    __render(): any;
-    __ensureInstance(): any;
-    __syncHostProperties(): any;
-    __teardownInstance(): any;
     _showHideChildren(): any;
   }
 }

--- a/src/test/goldens/polymer/lib/elements/dom-repeat.d.ts
+++ b/src/test/goldens/polymer/lib/elements/dom-repeat.d.ts
@@ -203,24 +203,6 @@ declare namespace Polymer {
     _targetFrameTime: number;
     disconnectedCallback(): any;
     connectedCallback(): any;
-    __ensureTemplatized(): any;
-    __getMethodHost(): any;
-    __sortChanged(sort: any): any;
-    __filterChanged(filter: any): any;
-    __computeFrameTime(rate: any): any;
-    __initializeChunking(): any;
-    __tryRenderChunk(): any;
-    __requestRenderChunk(): any;
-    __renderChunk(): any;
-    __observeChanged(): any;
-    __itemsChanged(change: any): any;
-    __handleObservedPaths(path: any): any;
-
-    /**
-     * @param fn Function to debounce.
-     * @param delay Delay in ms to debounce by.
-     */
-    __debounceRender(fn: () => any, delay?: number): any;
 
     /**
      * Forces the element to render its content. Normally rendering is
@@ -230,23 +212,11 @@ declare namespace Polymer {
      * validate application state.
      */
     render(): void|null;
-    __render(): any;
-    __applyFullRefresh(): any;
-    __detachInstance(idx: any): any;
-    __attachInstance(idx: any, parent: any): any;
-    __detachAndRemoveInstance(idx: any): any;
-    __stampInstance(item: any, instIdx: any, itemIdx: any): any;
-    __insertInstance(item: any, instIdx: any, itemIdx: any): any;
 
     /**
      * Implements extension point from Templatize mixin
      */
     _showHideChildren(hidden: any): any;
-
-    /**
-     * responsible for notifying item.<path> changes to inst for key
-     */
-    __handleItemPath(path: any, value: any): any;
 
     /**
      * Returns the item associated with a given element stamped by

--- a/src/test/goldens/polymer/lib/legacy/legacy-element-mixin.d.ts
+++ b/src/test/goldens/polymer/lib/legacy/legacy-element-mixin.d.ts
@@ -32,7 +32,6 @@ declare namespace Polymer {
 
   interface LegacyElementMixin {
     isAttached: boolean;
-    __boundListeners: any;
     _debouncers: any;
 
     /**

--- a/src/test/goldens/polymer/lib/mixins/dir-mixin.d.ts
+++ b/src/test/goldens/polymer/lib/mixins/dir-mixin.d.ts
@@ -33,7 +33,6 @@ declare namespace Polymer {
   } & T
 
   interface DirMixin {
-    __autoDirOptOut: boolean;
     ready(): any;
     connectedCallback(): any;
     disconnectedCallback(): any;

--- a/src/test/goldens/polymer/lib/mixins/property-accessors.d.ts
+++ b/src/test/goldens/polymer/lib/mixins/property-accessors.d.ts
@@ -36,17 +36,6 @@ declare namespace Polymer {
   } & T
 
   interface PropertyAccessors {
-    __serializing: boolean;
-    __dataCounter: number;
-    __dataEnabled: boolean;
-    __dataReady: boolean;
-    __dataInvalid: boolean;
-    __data: Object;
-    __dataPending: Object|null;
-    __dataOld: Object|null;
-    __dataProto: Object|null;
-    __dataHasAccessor: Object|null;
-    __dataInstanceProps: Object|null;
 
     /**
      * Implements native Custom Elements `attributeChangedCallback` to

--- a/src/test/goldens/polymer/lib/mixins/property-effects.d.ts
+++ b/src/test/goldens/polymer/lib/mixins/property-effects.d.ts
@@ -50,26 +50,6 @@ declare namespace Polymer {
   } & T
 
   interface PropertyEffects {
-    __dataCounter: number;
-    __data: Object;
-    __dataPending: Object;
-    __dataOld: Object;
-    __dataClientsReady: boolean;
-    __dataPendingClients: any[]|null;
-    __dataToNotify: Object|null;
-    __dataLinkedPaths: Object|null;
-    __dataHasPaths: boolean;
-    __dataCompoundStorage: Object|null;
-    __dataHost: Polymer_PropertyEffects|null;
-    __dataTemp: Object;
-    __dataClientsInitialized: boolean;
-    __computeEffects: Object|null;
-    __reflectEffects: Object|null;
-    __notifyEffects: Object|null;
-    __propagateEffects: Object|null;
-    __observeEffects: Object|null;
-    __readOnly: Object|null;
-    __templateInfo: TemplateInfo;
 
     /**
      * Stamps the provided template and performs instance-time setup for
@@ -305,11 +285,6 @@ declare namespace Polymer {
      * their `_flushProperties` method to run.
      */
     _flushClients(): void|null;
-
-    /**
-     * (c) the stamped dom enables.
-     */
-    __enableOrFlushClients(): any;
 
     /**
      * Perform any initial setup on client dom. Called before the first

--- a/src/test/goldens/polymer/lib/utils/templatize.d.ts
+++ b/src/test/goldens/polymer/lib/utils/templatize.d.ts
@@ -25,14 +25,6 @@ declare class TemplateInstanceBase extends
   _setUnmanagedPropertyToNode(node: any, prop: any, value: any): any;
 
   /**
-   * Configure the given `props` by calling `_setPendingProperty`. Also
-   * sets any properties stored in `__hostProps`.
-   *
-   * @param props Object of property name-value pairs to set.
-   */
-  _configureProperties(props: Object|null): void|null;
-
-  /**
    * Forwards a host property to this instance.  This method should be
    * called on instances from the `options.forwardHostProp` callback
    * to propagate changes of host properties to each instance.
@@ -53,9 +45,6 @@ declare class TemplateInstanceBase extends
    * set to false to show them.
    */
   _showHideChildren(hide: boolean): void|null;
-}
-
-declare class klass {
 }
 
 declare namespace templateInfo {
@@ -140,10 +129,4 @@ declare namespace Polymer {
      */
     function modelForElement(template: HTMLTemplateElement|null, node: Node|null): TemplateInstanceBase|null;
   }
-}
-
-/**
- * Subclass base class and add reference for this specific template
- */
-declare class klass {
 }


### PR DESCRIPTION
Depends on https://github.com/Polymer/polymer/commit/704aadcbd97eda76ef3478620bdfc2eb237a51c6 which annotates two `klass` classes as `@private`.

Part of https://github.com/Polymer/gen-typescript-declarations/issues/23