### PR TITLE
Add removeReferences config option.

### DIFF
--- a/src/test/goldens/polymer/lib/elements/custom-style.d.ts
+++ b/src/test/goldens/polymer/lib/elements/custom-style.d.ts
@@ -8,7 +8,6 @@
  *   lib/elements/custom-style.html
  */
 
-/// <reference path="../../../shadycss/custom-style-interface.d.ts" />
 /// <reference path="../utils/style-gather.d.ts" />
 
 declare namespace Polymer {

--- a/src/test/goldens/polymer/lib/legacy/legacy-element-mixin.d.ts
+++ b/src/test/goldens/polymer/lib/legacy/legacy-element-mixin.d.ts
@@ -8,7 +8,6 @@
  *   lib/legacy/legacy-element-mixin.html
  */
 
-/// <reference path="../../../shadycss/apply-shim.d.ts" />
 /// <reference path="../mixins/element-mixin.d.ts" />
 /// <reference path="../mixins/gesture-event-listeners.d.ts" />
 /// <reference path="../mixins/dir-mixin.d.ts" />


### PR DESCRIPTION
This option will remove any triple-slash references to these type declaration files, specified as paths relative to the analysis root directory.

This is useful for pruning out generated references that we don't actually need, e.g. from Polymer to ShadyCSS.

Also renames `augment` to `addReferences`, because I think the two make more sense together this way.

Depends on https://github.com/Polymer/polymer/pull/4928/commits/1f92cca5e6ce0c31855a76d67a5454150beeb3a8

Part of https://github.com/Polymer/gen-typescript-declarations/issues/23