### PR TITLE
Constructors, records, void returns, method descs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
 - `void` is not nullable.
+- Support constructor functions (e.g. `function(new:HTMLElement, string)`).
+- Support record types (e.g. `@param {{foo: bar}}`).
+- Include method `@return` descriptions.
 
 ## [0.2.0] - 2017-12-08
 - Many fixes. See https://github.com/Polymer/gen-typescript-declarations/issues/23.

--- a/src/closure-types.ts
+++ b/src/closure-types.ts
@@ -133,6 +133,8 @@ function convert(node: doctrine.Type, templateTypes: string[]): ts.Type {
     t = ts.nullType;
   } else if (isUndefinedLiteral(node)) {  // undefined
     t = ts.undefinedType;
+  } else if (isVoidLiteral(node)) {  // void
+    t = new ts.NameType('void');
   } else if (isName(node)) {  // string, Object, MyClass, etc.
     t = new ts.NameType(node.name);
   } else {
@@ -237,6 +239,10 @@ function isNullableLiteral(node: doctrine.Type):
 function isUndefinedLiteral(node: doctrine.Type):
     node is doctrine.type.UndefinedLiteral {
   return node.type === 'UndefinedLiteral';
+}
+
+function isVoidLiteral(node: doctrine.Type): node is doctrine.type.VoidLiteral {
+  return node.type === 'VoidLiteral';
 }
 
 function isName(node: doctrine.Type): node is doctrine.type.NameExpression {

--- a/src/gen-ts.ts
+++ b/src/gen-ts.ts
@@ -326,7 +326,8 @@ function handleFunction(feature: AnalyzerFunction, root: ts.Document) {
     description: feature.description || feature.summary,
     templateTypes: feature.templateTypes,
     returns: closureTypeToTypeScript(
-        feature.return && feature.return.type, feature.templateTypes)
+        feature.return && feature.return.type, feature.templateTypes),
+    returnsDescription: feature.return && feature.return.desc
   });
 
   for (const param of feature.params || []) {

--- a/src/test/closure-types_test.ts
+++ b/src/test/closure-types_test.ts
@@ -103,6 +103,8 @@ suite('closureTypeToTypeScript', () => {
     check(
         'function(string, number): boolean',
         '(p0: string, p1: number) => boolean');
+
+    check('function(): void', '() => void');
   });
 
   test('function object', () => {

--- a/src/test/closure-types_test.ts
+++ b/src/test/closure-types_test.ts
@@ -113,6 +113,12 @@ suite('closureTypeToTypeScript', () => {
     check('!Function', 'Function');
   });
 
+  test('constructor', () => {
+    check('function(new:HTMLElement)', '{new(): HTMLElement}');
+    check(
+        'function(new:HTMLElement, string)', '{new(p0: string): HTMLElement}');
+  });
+
   test('returns any when invalid', () => {
     check('><', 'any');
   });

--- a/src/test/closure-types_test.ts
+++ b/src/test/closure-types_test.ts
@@ -123,7 +123,7 @@ suite('closureTypeToTypeScript', () => {
     check('{foo:string}', '{foo: string}');
     check('{foo:string, bar:number}', '{foo: string, bar: number}');
     check('{foo, bar}', '{foo: any, bar: any}');
-    check('{foo:(string|undefined)}', '{foo: string|undefined}');
+    check('{foo:(string|undefined)}', '{foo?: string}');
   });
 
   test('returns any when invalid', () => {

--- a/src/test/closure-types_test.ts
+++ b/src/test/closure-types_test.ts
@@ -119,6 +119,13 @@ suite('closureTypeToTypeScript', () => {
         'function(new:HTMLElement, string)', '{new(p0: string): HTMLElement}');
   });
 
+  test('record', () => {
+    check('{foo:string}', '{foo: string}');
+    check('{foo:string, bar:number}', '{foo: string, bar: number}');
+    check('{foo, bar}', '{foo: any, bar: any}');
+    check('{foo:(string|undefined)}', '{foo: string|undefined}');
+  });
+
   test('returns any when invalid', () => {
     check('><', 'any');
   });

--- a/src/test/goldens/polymer/lib/legacy/class.d.ts
+++ b/src/test/goldens/polymer/lib/legacy/class.d.ts
@@ -19,6 +19,9 @@ declare namespace Polymer {
    * Note: this method will automatically also apply the `Polymer.LegacyElementMixin`
    * to ensure that any legacy behaviors can rely on legacy Polymer API on
    * the underlying element.
+   *
+   * @returns Returns a new Element class extended by the
+   * passed in `behaviors` and also by `Polymer.LegacyElementMixin`.
    */
   function mixinBehaviors(behaviors: Object|any[]|null, klass: HTMLElement|{new(): HTMLElement}): {new(): HTMLElement};
 
@@ -85,6 +88,8 @@ declare namespace Polymer {
    * - `ready`: called before first `attached`, after all properties of
    *   this element have been propagated to its template and all observers
    *   have run
+   *
+   * @returns Generated class
    */
   function Class(info: PolymerInit): {new(): HTMLElement};
 }

--- a/src/test/goldens/polymer/lib/legacy/class.d.ts
+++ b/src/test/goldens/polymer/lib/legacy/class.d.ts
@@ -20,7 +20,7 @@ declare namespace Polymer {
    * to ensure that any legacy behaviors can rely on legacy Polymer API on
    * the underlying element.
    */
-  function mixinBehaviors(behaviors: Object|any[]|null, klass: HTMLElement|(() => any)): () => any;
+  function mixinBehaviors(behaviors: Object|any[]|null, klass: HTMLElement|{new(): HTMLElement}): {new(): HTMLElement};
 
 
   /**
@@ -86,7 +86,7 @@ declare namespace Polymer {
    *   this element have been propagated to its template and all observers
    *   have run
    */
-  function Class(info: PolymerInit): () => any;
+  function Class(info: PolymerInit): {new(): HTMLElement};
 }
 
 declare class PolymerGenerated {

--- a/src/test/goldens/polymer/lib/legacy/legacy-element-mixin.d.ts
+++ b/src/test/goldens/polymer/lib/legacy/legacy-element-mixin.d.ts
@@ -238,7 +238,7 @@ declare namespace Polymer {
      *  `node` on which to fire the event (HTMLElement, defaults to `this`).
      * @returns The new event that was fired.
      */
-    fire(type: string, detail?: any, options?: {bubbles: boolean|undefined, cancelable: boolean|undefined, composed: boolean|undefined}): Event|null;
+    fire(type: string, detail?: any, options?: {bubbles?: boolean, cancelable?: boolean, composed?: boolean}): Event|null;
 
     /**
      * Convenience method to add an event listener on a given element,

--- a/src/test/goldens/polymer/lib/legacy/legacy-element-mixin.d.ts
+++ b/src/test/goldens/polymer/lib/legacy/legacy-element-mixin.d.ts
@@ -238,7 +238,7 @@ declare namespace Polymer {
      *  `node` on which to fire the event (HTMLElement, defaults to `this`).
      * @returns The new event that was fired.
      */
-    fire(type: string, detail?: any, options?: any): Event|null;
+    fire(type: string, detail?: any, options?: {bubbles: boolean|undefined, cancelable: boolean|undefined, composed: boolean|undefined}): Event|null;
 
     /**
      * Convenience method to add an event listener on a given element,

--- a/src/test/goldens/polymer/lib/legacy/polymer-fn.d.ts
+++ b/src/test/goldens/polymer/lib/legacy/polymer-fn.d.ts
@@ -19,5 +19,7 @@
  * `customElements.define(info.is, Polymer.Class(info));`
  *
  * See `Polymer.Class` for details on valid legacy metadata format for `info`.
+ *
+ * @returns Generated class
  */
 declare function Polymer(info: PolymerInit): HTMLElement;

--- a/src/test/goldens/polymer/lib/legacy/polymer.dom.d.ts
+++ b/src/test/goldens/polymer/lib/legacy/polymer.dom.d.ts
@@ -29,6 +29,8 @@ declare namespace Polymer {
 
     /**
      * Cross-platform `element.matches` shim.
+     *
+     * @returns True if node matched selector
      */
     function matchesSelector(node: Element, selector: string): boolean;
   }
@@ -133,6 +135,8 @@ declare namespace Polymer {
    * Note that in Polymer 2.x use of `Polymer.dom` is no longer required and
    * in the majority of cases simply facades directly to the standard native
    * API.
+   *
+   * @returns Wrapper providing either node API or event API
    */
   function dom(obj: Node|Event|null): DomApi|EventApi|null;
 }

--- a/src/test/goldens/polymer/lib/utils/array-splice.d.ts
+++ b/src/test/goldens/polymer/lib/utils/array-splice.d.ts
@@ -38,6 +38,11 @@ declare namespace Polymer {
      * to detect any shared prefix & suffix between the two arrays and only
      * perform the more expensive minimum edit distance calculation over the
      * non-shared portions of the arrays.
+     *
+     * @returns Returns an array of splice record objects. Each of these
+     * contains: `index` the location where the splice occurred; `removed`
+     * the array of removed items from this location; `addedCount` the number
+     * of items added at this location.
      */
     function calculateSplices(current: any[]|null, previous: any[]|null): any[]|null;
   }

--- a/src/test/goldens/polymer/lib/utils/async.d.ts
+++ b/src/test/goldens/polymer/lib/utils/async.d.ts
@@ -29,12 +29,16 @@ declare namespace Polymer {
       /**
        * Returns a sub-module with the async interface providing the provided
        * delay.
+       *
+       * @returns An async timeout interface
        */
       function after(delay: number): AsyncInterface|null;
 
 
       /**
        * Enqueues a function called in the next task.
+       *
+       * @returns Handle used for canceling task
        */
       function run(fn: Function|null): number;
 
@@ -59,6 +63,8 @@ declare namespace Polymer {
 
       /**
        * Enqueues a function called at `requestAnimationFrame` timing.
+       *
+       * @returns Handle used for canceling task
        */
       function run(fn: Function|null): number;
     }
@@ -72,6 +78,8 @@ declare namespace Polymer {
 
       /**
        * Enqueues a function called at `requestIdleCallback` timing.
+       *
+       * @returns Handle used for canceling task
        */
       function run(fn: (p0: IdleDeadline|null) => any): number;
 
@@ -96,6 +104,8 @@ declare namespace Polymer {
 
       /**
        * Enqueues a function called at microtask timing.
+       *
+       * @returns Handle used for canceling task
        */
       function run(callback: Function|null): number;
 

--- a/src/test/goldens/polymer/lib/utils/case-map.d.ts
+++ b/src/test/goldens/polymer/lib/utils/case-map.d.ts
@@ -22,6 +22,8 @@ declare namespace Polymer {
     /**
      * Converts "dash-case" identifier (e.g. `foo-bar-baz`) to "camelCase"
      * (e.g. `fooBarBaz`).
+     *
+     * @returns Camel-case representation of the identifier
      */
     function dashToCamelCase(dash: string): string;
 
@@ -29,6 +31,8 @@ declare namespace Polymer {
     /**
      * Converts "camelCase" identifier (e.g. `fooBarBaz`) to "dash-case"
      * (e.g. `foo-bar-baz`).
+     *
+     * @returns Dash-case representation of the identifier
      */
     function camelToDashCase(camel: string): string;
   }

--- a/src/test/goldens/polymer/lib/utils/gestures.d.ts
+++ b/src/test/goldens/polymer/lib/utils/gestures.d.ts
@@ -30,18 +30,25 @@ declare namespace Polymer {
      *
      * Similar to `document.elementFromPoint`, but pierces through
      * shadow roots.
+     *
+     * @returns Returns the deepest shadowRoot inclusive element
+     * found at the screen position given.
      */
     function deepTargetFind(x: number, y: number): Element|null;
 
 
     /**
      * Adds an event listener to a node for the given gesture type.
+     *
+     * @returns Returns true if a gesture event listener was added.
      */
     function addListener(node: Node|null, evType: string, handler: Function|null): boolean;
 
 
     /**
      * Removes an event listener from a node for the given gesture type.
+     *
+     * @returns Returns true if a gesture event listener was removed.
      */
     function removeListener(node: Node|null, evType: string, handler: Function|null): boolean;
 

--- a/src/test/goldens/polymer/lib/utils/html-tag.d.ts
+++ b/src/test/goldens/polymer/lib/utils/html-tag.d.ts
@@ -34,6 +34,8 @@ declare namespace Polymer {
    *     `;
    *   }
    *   static get partialTemplate() { return Polymer.html`<span>Partial!</span>`; }
+   *
+   * @returns Constructed HTMLTemplateElement
    */
   function html(strings: string[], ...values: any[]): HTMLTemplateElement;
 }

--- a/src/test/goldens/polymer/lib/utils/import-href.d.ts
+++ b/src/test/goldens/polymer/lib/utils/import-href.d.ts
@@ -20,6 +20,8 @@ declare namespace Polymer {
    * the provided URL and appends it to the document to start loading.
    * In the `onload` callback, the `import` property of the `link`
    * element will contain the imported document contents.
+   *
+   * @returns The link element for the URL to be loaded.
    */
   function importHref(href: string, onload?: Function|null, onerror?: Function|null, optAsync?: boolean): HTMLLinkElement|null;
 }

--- a/src/test/goldens/polymer/lib/utils/path.d.ts
+++ b/src/test/goldens/polymer/lib/utils/path.d.ts
@@ -27,6 +27,8 @@ declare namespace Polymer {
      * Polymer.Path.isPath('foo.bar.baz') // true
      * Polymer.Path.isPath('foo')         // false
      * ```
+     *
+     * @returns True if the string contained one or more dots
      */
     function isPath(path: string): boolean;
 
@@ -40,6 +42,8 @@ declare namespace Polymer {
      * Polymer.Path.root('foo.bar.baz') // 'foo'
      * Polymer.Path.root('foo')         // 'foo'
      * ```
+     *
+     * @returns Root property name
      */
     function root(path: string): string;
 
@@ -55,6 +59,8 @@ declare namespace Polymer {
      * Polymer.Path.isAncestor('foo.bar', 'foo.bar')     // false
      * Polymer.Path.isAncestor('foo.bar', 'foo.bar.baz') // false
      * ```
+     *
+     * @returns True if `path` is an ancestor of `base`.
      */
     function isAncestor(base: string, path: string): boolean;
 
@@ -69,6 +75,8 @@ declare namespace Polymer {
      * Polymer.Path.isDescendant('foo.bar', 'foo.bar')     // false
      * Polymer.Path.isDescendant('foo.bar', 'foo')         // false
      * ```
+     *
+     * @returns True if `path` is a descendant of `base`.
      */
     function isDescendant(base: string, path: string): boolean;
 
@@ -84,6 +92,8 @@ declare namespace Polymer {
      * ```
      * Polymer.Path.translate('foo.bar', 'zot', 'foo.bar.baz') // 'zot.baz'
      * ```
+     *
+     * @returns Translated string
      */
     function translate(base: string, newBase: string, path: string): string;
 
@@ -98,6 +108,8 @@ declare namespace Polymer {
      * Polymer.Path.normalize(['foo.bar', 0, 'baz'])  // 'foo.bar.0.baz'
      * Polymer.Path.normalize('foo.bar.0.baz')        // 'foo.bar.0.baz'
      * ```
+     *
+     * @returns Flattened path
      */
     function normalize(path: string|Array<string|number>): string;
 
@@ -112,6 +124,8 @@ declare namespace Polymer {
      * Polymer.Path.split(['foo.bar', 0, 'baz'])  // ['foo', 'bar', '0', 'baz']
      * Polymer.Path.split('foo.bar.0.baz')        // ['foo', 'bar', '0', 'baz']
      * ```
+     *
+     * @returns Array of path parts
      */
     function split(path: string|Array<string|number>): string[];
 
@@ -119,6 +133,9 @@ declare namespace Polymer {
     /**
      * Reads a value from a path.  If any sub-property in the path is `undefined`,
      * this method returns `undefined` (will never throw.
+     *
+     * @returns Value at path, or `undefined` if the path could not be
+     *  fully dereferenced.
      */
     function get(root: Object|null, path: string|Array<string|number>, info?: Object|null): any;
 
@@ -126,6 +143,8 @@ declare namespace Polymer {
     /**
      * Sets a value to a path.  If any sub-property in the path is `undefined`,
      * this method will no-op.
+     *
+     * @returns The normalized version of the input path
      */
     function set(root: Object|null, path: string|Array<string|number>, value: any): string|undefined;
   }

--- a/src/test/goldens/polymer/lib/utils/resolve-url.d.ts
+++ b/src/test/goldens/polymer/lib/utils/resolve-url.d.ts
@@ -20,6 +20,8 @@ declare namespace Polymer {
 
     /**
      * Resolves the given URL against the provided `baseUri'.
+     *
+     * @returns resolved URL
      */
     function resolveUrl(url: string, baseURI?: string|null): string;
 
@@ -27,6 +29,8 @@ declare namespace Polymer {
     /**
      * Resolves any relative URL's in the given CSS text against the provided
      * `ownerDocument`'s `baseURI`.
+     *
+     * @returns Processed CSS text with resolved URL's
      */
     function resolveCss(cssText: string, baseURI: string): string;
 
@@ -34,6 +38,8 @@ declare namespace Polymer {
     /**
      * Returns a path from a given `url`. The path includes the trailing
      * `/` from the url.
+     *
+     * @returns resolved path
      */
     function pathFromUrl(url: string): string;
   }

--- a/src/test/goldens/polymer/lib/utils/style-gather.d.ts
+++ b/src/test/goldens/polymer/lib/utils/style-gather.d.ts
@@ -21,6 +21,8 @@ declare namespace Polymer {
 
     /**
      * Returns a list of <style> elements in a space-separated list of `dom-module`s.
+     *
+     * @returns Array of contained <style> elements
      */
     function stylesFromModules(moduleIds: string): any[]|null;
 
@@ -30,27 +32,39 @@ declare namespace Polymer {
      * Styles in a `dom-module` can come either from `<style>`s within the
      * first `<template>`, or else from one or more
      * `<link rel="import" type="css">` links outside the template.
+     *
+     * @returns Array of contained styles.
      */
     function stylesFromModule(moduleId: string): any[]|null;
 
 
     /**
      * Returns the `<style>` elements within a given template.
+     *
+     * @returns Array of styles
      */
     function stylesFromTemplate(template: HTMLTemplateElement|null, baseURI: string): any[]|null;
 
 
     /**
      * Returns a list of <style> elements  from stylesheets loaded via `<link rel="import" type="css">` links within the specified `dom-module`.
+     *
+     * @returns Array of contained styles.
      */
     function stylesFromModuleImports(moduleId: string): any[]|null;
 
+
+    /**
+     * @returns Array of contained styles
+     */
     function _stylesFromModuleImports(module: HTMLElement): any[]|null;
 
 
     /**
      * Returns CSS text of styles in a space-separated list of `dom-module`s.
      * Note: This method is deprecated, use `stylesFromModules` instead.
+     *
+     * @returns Concatenated CSS content from specified `dom-module`s
      */
     function cssFromModules(moduleIds: string): string;
 
@@ -63,6 +77,8 @@ declare namespace Polymer {
      *
      * Any `<styles>` processed are removed from their original location.
      * Note: This method is deprecated, use `styleFromModule` instead.
+     *
+     * @returns Concatenated CSS content from specified `dom-module`
      */
     function cssFromModule(moduleId: string): string;
 
@@ -72,6 +88,8 @@ declare namespace Polymer {
      *
      * Any `<styles>` processed are removed from their original location.
      * Note: This method is deprecated, use `styleFromTemplate` instead.
+     *
+     * @returns Concatenated CSS content from specified template
      */
     function cssFromTemplate(template: HTMLTemplateElement|null, baseURI: string): string;
 
@@ -81,9 +99,15 @@ declare namespace Polymer {
      * links within the specified `dom-module`.
      *
      * Note: This method is deprecated, use `stylesFromModuleImports` instead.
+     *
+     * @returns Concatenated CSS content from links in specified `dom-module`
      */
     function cssFromModuleImports(moduleId: string): string;
 
+
+    /**
+     * @returns Concatenated CSS content from links in the dom-module
+     */
     function _cssFromModuleImports(module: HTMLElement): string;
   }
 }

--- a/src/test/goldens/polymer/lib/utils/templatize.d.ts
+++ b/src/test/goldens/polymer/lib/utils/templatize.d.ts
@@ -109,6 +109,9 @@ declare namespace Polymer {
      * used; rather, callbacks are called bound to the `owner`, and so context
      * needed from the callbacks (such as references to `instances` stamped)
      * should be stored on the `owner` such that they can be retrieved via `this`.
+     *
+     * @returns Generated class bound to the template
+     *   provided
      */
     function templatize(template: HTMLTemplateElement, owner: Polymer_PropertyEffects, options?: Object|null): {new(): TemplateInstanceBase};
 
@@ -126,6 +129,9 @@ declare namespace Polymer {
      *   if (model.index < 10) {
      *     model.set('item.checked', true);
      *   }
+     *
+     * @returns Template instance representing the
+     *   binding scope for the element
      */
     function modelForElement(template: HTMLTemplateElement|null, node: Node|null): TemplateInstanceBase|null;
   }

--- a/src/test/goldens/polymer/lib/utils/templatize.d.ts
+++ b/src/test/goldens/polymer/lib/utils/templatize.d.ts
@@ -110,7 +110,7 @@ declare namespace Polymer {
      * needed from the callbacks (such as references to `instances` stamped)
      * should be stored on the `owner` such that they can be retrieved via `this`.
      */
-    function templatize(template: HTMLTemplateElement, owner: Polymer_PropertyEffects, options?: Object|null): () => any;
+    function templatize(template: HTMLTemplateElement, owner: Polymer_PropertyEffects, options?: Object|null): {new(): TemplateInstanceBase};
 
 
     /**

--- a/src/ts-ast.ts
+++ b/src/ts-ast.ts
@@ -633,19 +633,21 @@ export class ParamType {
   readonly kind = 'param';
   name: string;
   type: Type;
+  optional: boolean;
 
   * traverse(): Iterable<Node> {
     yield* this.type.traverse();
     yield this;
   }
 
-  constructor(name: string, type: Type) {
+  constructor(name: string, type: Type, optional: boolean = false) {
     this.name = name;
     this.type = type;
+    this.optional = optional;
   }
 
   serialize() {
-    return `${this.name}: ${this.type.serialize()}`;
+    return `${this.name}${this.optional ? '?' : ''}: ${this.type.serialize()}`;
   }
 }
 

--- a/src/ts-ast.ts
+++ b/src/ts-ast.ts
@@ -450,7 +450,8 @@ export class Param {
 }
 
 // A TypeScript type expression.
-export type Type = NameType|UnionType|ArrayType|FunctionType|ConstructorType;
+export type Type =
+    NameType|UnionType|ArrayType|FunctionType|ConstructorType|RecordType;
 
 // string, MyClass, null, undefined, any
 export class NameType {
@@ -597,8 +598,7 @@ export class FunctionType {
   }
 
   serialize(): string {
-    const params =
-        this.params.map((param) => `${param.name}: ${param.type.serialize()}`);
+    const params = this.params.map((param) => param.serialize());
     return `(${params.join(', ')}) => ${this.returns.serialize()}`;
   }
 }
@@ -623,8 +623,7 @@ export class ConstructorType {
   }
 
   serialize(): string {
-    const params =
-        this.params.map((param) => `${param.name}: ${param.type.serialize()}`);
+    const params = this.params.map((param) => param.serialize());
     return `{new(${params.join(', ')}): ${this.returns.serialize()}}`;
   }
 }
@@ -643,6 +642,31 @@ export class ParamType {
   constructor(name: string, type: Type) {
     this.name = name;
     this.type = type;
+  }
+
+  serialize() {
+    return `${this.name}: ${this.type.serialize()}`;
+  }
+}
+
+export class RecordType {
+  readonly kind = 'record';
+  fields: ParamType[];
+
+  constructor(fields: ParamType[]) {
+    this.fields = fields;
+  }
+
+  * traverse(): Iterable<Node> {
+    for (const m of this.fields) {
+      yield* m.traverse();
+    }
+    yield this;
+  }
+
+  serialize(): string {
+    const fields = this.fields.map((field) => field.serialize());
+    return `{${fields.join(', ')}}`;
   }
 }
 

--- a/src/ts-ast.ts
+++ b/src/ts-ast.ts
@@ -450,7 +450,7 @@ export class Param {
 }
 
 // A TypeScript type expression.
-export type Type = NameType|UnionType|ArrayType|FunctionType;
+export type Type = NameType|UnionType|ArrayType|FunctionType|ConstructorType;
 
 // string, MyClass, null, undefined, any
 export class NameType {
@@ -600,6 +600,32 @@ export class FunctionType {
     const params =
         this.params.map((param) => `${param.name}: ${param.type.serialize()}`);
     return `(${params.join(', ')}) => ${this.returns.serialize()}`;
+  }
+}
+
+// {new(foo): bar}
+export class ConstructorType {
+  readonly kind = 'constructor';
+  params: ParamType[];
+  returns: NameType;
+
+  constructor(params: ParamType[], returns: NameType) {
+    this.params = params;
+    this.returns = returns;
+  }
+
+  * traverse(): Iterable<Node> {
+    for (const p of this.params) {
+      yield* p.traverse();
+    }
+    yield* this.returns.traverse();
+    yield this;
+  }
+
+  serialize(): string {
+    const params =
+        this.params.map((param) => `${param.name}: ${param.type.serialize()}`);
+    return `{new(${params.join(', ')}): ${this.returns.serialize()}}`;
   }
 }
 


### PR DESCRIPTION
- Support constructors (e.g. `function(new:HTMLElement, string)`).
- Support record types (e.g. `@param {{foo: bar}}`).
- Support `void` function return types.
- Include method `@returns` descriptions.

Resolves a number of comments in https://github.com/Polymer/polymer/pull/4928