### PR TITLE
Convert Closure "Object" to TypeScript "object" instead of "Object".

### DIFF
--- a/src/closure-types.ts
+++ b/src/closure-types.ts
@@ -137,7 +137,14 @@ function convert(node: doctrine.Type, templateTypes: string[]): ts.Type {
   } else if (isVoidLiteral(node)) {  // void
     t = new ts.NameType('void');
   } else if (isName(node)) {  // string, Object, MyClass, etc.
-    t = new ts.NameType(node.name);
+    if (node.name === 'Object') {
+      // Closure's `Object` type excludes primitives, so it is closest to
+      // TypeScript's `object`. (Technically this should be `object|Symbol`,
+      // but we will concede that technicality.)
+      t = new ts.NameType('object');
+    } else {
+      t = new ts.NameType(node.name);
+    }
   } else {
     console.error('Unknown syntax.');
     return ts.anyType;

--- a/src/test/closure-types_test.ts
+++ b/src/test/closure-types_test.ts
@@ -49,12 +49,12 @@ suite('closureTypeToTypeScript', () => {
   });
 
   test('nullable object', () => {
-    check('Object', 'Object|null');
-    check('?Object', 'Object|null');
+    check('Object', 'object|null');
+    check('?Object', 'object|null');
   });
 
   test('non-nullable object', () => {
-    check('!Object', 'Object');
+    check('!object', 'object');
   });
 
   test('nullable array', () => {

--- a/src/test/goldens/paper-behaviors/paper-button-behavior.d.ts
+++ b/src/test/goldens/paper-behaviors/paper-button-behavior.d.ts
@@ -22,7 +22,7 @@ declare namespace Polymer {
      * than the last.
      */
     elevation: number;
-    hostAttributes: Object|null;
+    hostAttributes: object|null;
 
     /**
      * In addition to `IronButtonState` behavior, when space key goes down,

--- a/src/test/goldens/polymer/lib/elements/array-selector.d.ts
+++ b/src/test/goldens/polymer/lib/elements/array-selector.d.ts
@@ -51,13 +51,13 @@ declare namespace Polymer {
      * When `multi` is false, this is the currently selected item, or `null`
      * if no item is selected.
      */
-    selected: Object|Object[]|null;
+    selected: object|object[]|null;
 
     /**
      * When `multi` is false, this is the currently selected item, or `null`
      * if no item is selected.
      */
-    selectedItem: Object|null;
+    selectedItem: object|null;
 
     /**
      * When `true`, calling `select` on an item that is already selected

--- a/src/test/goldens/polymer/lib/legacy/class.d.ts
+++ b/src/test/goldens/polymer/lib/legacy/class.d.ts
@@ -23,7 +23,7 @@ declare namespace Polymer {
    * @returns Returns a new Element class extended by the
    * passed in `behaviors` and also by `Polymer.LegacyElementMixin`.
    */
-  function mixinBehaviors(behaviors: Object|any[]|null, klass: HTMLElement|{new(): HTMLElement}): {new(): HTMLElement};
+  function mixinBehaviors(behaviors: object|any[]|null, klass: HTMLElement|{new(): HTMLElement}): {new(): HTMLElement};
 
 
   /**

--- a/src/test/goldens/polymer/lib/legacy/legacy-element-mixin.d.ts
+++ b/src/test/goldens/polymer/lib/legacy/legacy-element-mixin.d.ts
@@ -187,7 +187,7 @@ declare namespace Polymer {
      * @param api Source object to copy properties from.
      * @returns prototype object that was passed as first argument.
      */
-    extend(prototype: Object|null, api: Object|null): Object|null;
+    extend(prototype: object|null, api: object|null): object|null;
 
     /**
      * Copies props from a source object to a target object.
@@ -200,7 +200,7 @@ declare namespace Polymer {
      * @param source Source object to copy properties from.
      * @returns Target object that was passed as first argument.
      */
-    mixin(target: Object|null, source: Object|null): Object|null;
+    mixin(target: object|null, source: object|null): object|null;
 
     /**
      * Sets the prototype of an object.
@@ -214,7 +214,7 @@ declare namespace Polymer {
      * @returns Returns the given `object` with its prototype set
      * to the given `prototype` object.
      */
-    chainObject(object: Object|null, prototype: Object|null): Object|null;
+    chainObject(object: object|null, prototype: object|null): object|null;
 
     /**
      * Calls `importNode` on the `content` of the `template` specified and
@@ -435,7 +435,7 @@ declare namespace Polymer {
      * `flush()` immediately invokes the debounced callback if the debouncer
      * is active.
      */
-    debounce(jobName: string, callback: () => void, wait: number): Object|null;
+    debounce(jobName: string, callback: () => void, wait: number): object|null;
 
     /**
      * Returns whether a named debouncer is active.
@@ -489,7 +489,7 @@ declare namespace Polymer {
      *    instance.
      * @returns Newly created and configured element.
      */
-    create(tag: string, props: Object|null): Element|null;
+    create(tag: string, props: object|null): Element|null;
 
     /**
      * Convenience method for importing an HTML document imperatively.

--- a/src/test/goldens/polymer/lib/legacy/templatizer-behavior.d.ts
+++ b/src/test/goldens/polymer/lib/legacy/templatizer-behavior.d.ts
@@ -97,7 +97,7 @@ declare namespace Polymer {
      * @returns Returns the created instance of
      * the template prepared by `templatize`.
      */
-    stamp(model?: Object|null): TemplateInstanceBase|null;
+    stamp(model?: object|null): TemplateInstanceBase|null;
 
     /**
      * Returns the template "model" (`TemplateInstance`) associated with

--- a/src/test/goldens/polymer/lib/mixins/element-mixin.d.ts
+++ b/src/test/goldens/polymer/lib/mixins/element-mixin.d.ts
@@ -169,7 +169,7 @@ declare namespace Polymer {
      * @param properties Bag of custom property key/values to
      *   apply to this element.
      */
-    updateStyles(properties?: Object|null): void;
+    updateStyles(properties?: object|null): void;
 
     /**
      * Rewrites a given URL relative to a base URL. The base URL defaults to

--- a/src/test/goldens/polymer/lib/mixins/property-accessors.d.ts
+++ b/src/test/goldens/polymer/lib/mixins/property-accessors.d.ts
@@ -66,7 +66,7 @@ declare namespace Polymer {
      * @param props Bag of property values that were overwritten
      *   when creating property accessors.
      */
-    _initializeProtoProperties(props: Object|null): void;
+    _initializeProtoProperties(props: object|null): void;
 
     /**
      * Called at ready time with bag of instance properties that overwrote
@@ -79,7 +79,7 @@ declare namespace Polymer {
      * @param props Bag of property values that were overwritten
      *   when creating property accessors.
      */
-    _initializeInstanceProperties(props: Object|null): void;
+    _initializeInstanceProperties(props: object|null): void;
 
     /**
      * Ensures the element has the given attribute. If it does not,
@@ -263,7 +263,7 @@ declare namespace Polymer {
      * @param oldProps Bag of previous values for each property
      *   in `changedProps`
      */
-    _propertiesChanged(currentProps: Object, changedProps: Object, oldProps: Object): any;
+    _propertiesChanged(currentProps: object, changedProps: object, oldProps: object): any;
 
     /**
      * Method called to determine whether a property value should be

--- a/src/test/goldens/polymer/lib/mixins/property-effects.d.ts
+++ b/src/test/goldens/polymer/lib/mixins/property-effects.d.ts
@@ -79,7 +79,7 @@ declare namespace Polymer {
      *
      * @param props Properties to initialize on the prototype
      */
-    _initializeProtoProperties(props: Object|null): any;
+    _initializeProtoProperties(props: object|null): any;
 
     /**
      * Overrides `Polymer.PropertyAccessors` implementation to avoid setting
@@ -87,7 +87,7 @@ declare namespace Polymer {
      *
      * @param props Properties to initialize on the instance
      */
-    _initializeInstanceProperties(props: Object|null): any;
+    _initializeInstanceProperties(props: object|null): any;
 
     /**
      * Overrides base implementation to ensure all accessors set `shouldNotify`
@@ -164,7 +164,7 @@ declare namespace Polymer {
      * @param type Effect type, from this.PROPERTY_EFFECT_TYPES
      * @param effect Effect metadata object
      */
-    _addPropertyEffect(property: string, type: string, effect?: Object|null): void;
+    _addPropertyEffect(property: string, type: string, effect?: object|null): void;
 
     /**
      * Removes the given property effect.
@@ -173,7 +173,7 @@ declare namespace Polymer {
      * @param type Effect type, from this.PROPERTY_EFFECT_TYPES
      * @param effect Effect metadata object to remove
      */
-    _removePropertyEffect(property: string, type: string, effect?: Object|null): void;
+    _removePropertyEffect(property: string, type: string, effect?: object|null): void;
 
     /**
      * Returns whether the current prototype/instance has a property effect
@@ -278,7 +278,7 @@ declare namespace Polymer {
      *
      * @param client PropertyEffects client to enqueue
      */
-    _enqueueClient(client: Object|null): void;
+    _enqueueClient(client: object|null): void;
 
     /**
      * Flushes any clients previously enqueued via `_enqueueClient`, causing
@@ -306,7 +306,7 @@ declare namespace Polymer {
      *   `props` will be set. By default, `setProperties` will not set
      *   `readOnly: true` root properties.
      */
-    setProperties(props: Object|null, setReadOnly?: boolean): void;
+    setProperties(props: object|null, setReadOnly?: boolean): void;
 
     /**
      * Called to propagate any property changes to stamped template nodes
@@ -316,7 +316,7 @@ declare namespace Polymer {
      * @param oldProps Bag of previous values for changed properties
      * @param hasPaths True with `props` contains one or more paths
      */
-    _propagatePropertyChanges(changedProps: Object|null, oldProps: Object|null, hasPaths: boolean): void;
+    _propagatePropertyChanges(changedProps: object|null, oldProps: object|null, hasPaths: boolean): void;
 
     /**
      * Aliases one data path as another, such that path notifications from one
@@ -385,7 +385,7 @@ declare namespace Polymer {
      * @returns Value at the path, or `undefined` if any part of the path
      *   is undefined.
      */
-    get(path: string|Array<string|number>, root?: Object|null): any;
+    get(path: string|Array<string|number>, root?: object|null): any;
 
     /**
      * Convenience method for setting a value to a path and notifying any
@@ -406,7 +406,7 @@ declare namespace Polymer {
      * @param root Root object from which the path is evaluated.
      *   When specified, no notification will occur.
      */
-    set(path: string|Array<string|number>, value: any, root?: Object|null): void;
+    set(path: string|Array<string|number>, value: any, root?: object|null): void;
 
     /**
      * Adds items onto the end of the array at the path specified.
@@ -529,7 +529,7 @@ declare namespace Polymer {
      * @param dynamicFn Boolean or object map indicating
      *   whether method names should be included as a dependency to the effect.
      */
-    _createMethodObserver(expression: string, dynamicFn?: boolean|Object|null): void;
+    _createMethodObserver(expression: string, dynamicFn?: boolean|object|null): void;
 
     /**
      * Equivalent to static `createNotifyingProperty` API but can be called on
@@ -559,7 +559,7 @@ declare namespace Polymer {
      * @param dynamicFn Boolean or object map indicating
      *   whether method names should be included as a dependency to the effect.
      */
-    _createComputedProperty(property: string, expression: string, dynamicFn?: boolean|Object|null): void;
+    _createComputedProperty(property: string, expression: string, dynamicFn?: boolean|object|null): void;
 
     /**
      * Equivalent to static `bindTemplate` API but can be called on

--- a/src/test/goldens/polymer/lib/utils/path.d.ts
+++ b/src/test/goldens/polymer/lib/utils/path.d.ts
@@ -137,7 +137,7 @@ declare namespace Polymer {
      * @returns Value at path, or `undefined` if the path could not be
      *  fully dereferenced.
      */
-    function get(root: Object|null, path: string|Array<string|number>, info?: Object|null): any;
+    function get(root: object|null, path: string|Array<string|number>, info?: object|null): any;
 
 
     /**
@@ -146,6 +146,6 @@ declare namespace Polymer {
      *
      * @returns The normalized version of the input path
      */
-    function set(root: Object|null, path: string|Array<string|number>, value: any): string|undefined;
+    function set(root: object|null, path: string|Array<string|number>, value: any): string|undefined;
   }
 }

--- a/src/test/goldens/polymer/lib/utils/templatize.d.ts
+++ b/src/test/goldens/polymer/lib/utils/templatize.d.ts
@@ -113,7 +113,7 @@ declare namespace Polymer {
      * @returns Generated class bound to the template
      *   provided
      */
-    function templatize(template: HTMLTemplateElement, owner: Polymer_PropertyEffects, options?: Object|null): {new(): TemplateInstanceBase};
+    function templatize(template: HTMLTemplateElement, owner: Polymer_PropertyEffects, options?: object|null): {new(): TemplateInstanceBase};
 
 
     /**


### PR DESCRIPTION
Closure's `Object` type excludes primitives, so it is closest to TypeScript's `object`. (Technically this should be `object|Symbol`, but we will concede that technicality.)