### PR TITLE
Static method support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Static methods are now supported on classes, elements, and mixins.
 
 ## [0.3.1] - 2017-12-15
 - Convert Closure `Object` to TypeScript `object`.

--- a/scripts/fixtures.txt
+++ b/scripts/fixtures.txt
@@ -1,3 +1,3 @@
 https://github.com/PolymerElements/paper-button.git v2.0.0 paper-button
 https://github.com/PolymerElements/paper-behaviors.git v2.0.1 paper-behaviors
-https://github.com/Polymer/polymer.git aomarks-typescript polymer
+https://github.com/Polymer/polymer.git a1f33174f7b6722a66d4d2d1cb9933a7f07016b5 polymer

--- a/src/gen-ts.ts
+++ b/src/gen-ts.ts
@@ -220,7 +220,10 @@ function handleElement(feature: analyzer.Element, root: ts.Document) {
           (isPolymerElement(feature) ? 'Polymer.Element' : 'HTMLElement'),
       mixins: feature.mixins.map((mixin) => mixin.identifier),
       properties: handleProperties(feature.properties.values()),
-      methods: handleMethods(feature.methods.values()),
+      methods: [
+        ...handleMethods(feature.staticMethods.values(), {isStatic: true}),
+        ...handleMethods(feature.methods.values()),
+      ]
     });
     parent.members.push(c);
 
@@ -232,6 +235,9 @@ function handleElement(feature: analyzer.Element, root: ts.Document) {
       name: shortName,
       description: feature.description || feature.summary,
       properties: handleProperties(feature.properties.values()),
+      // Don't worry about about static methods when we're not constructable.
+      // Since there's no handle to the constructor, they could never be
+      // called.
       methods: handleMethods(feature.methods.values()),
     });
 
@@ -343,7 +349,10 @@ function handleClass(feature: analyzer.Class, root: ts.Document) {
   const m = new ts.Class({name});
   m.description = feature.description;
   m.properties = handleProperties(feature.properties.values());
-  m.methods = handleMethods(feature.methods.values());
+  m.methods = [
+    ...handleMethods(feature.staticMethods.values(), {isStatic: true}),
+    ...handleMethods(feature.methods.values())
+  ];
   findOrCreateNamespace(root, namespacePath).members.push(m);
 }
 
@@ -402,8 +411,9 @@ function handleProperties(analyzerProperties: Iterable<analyzer.Property>):
  * Convert the given Analyzer methods to their TypeScript declaration
  * equivalent.
  */
-function handleMethods(analyzerMethods: Iterable<analyzer.Method>):
-    ts.Method[] {
+function handleMethods(
+    analyzerMethods: Iterable<analyzer.Method>,
+    opts?: {isStatic?: boolean}): ts.Method[] {
   const tsMethods = <ts.Method[]>[];
   for (const method of analyzerMethods) {
     if (method.inheritedFrom || method.privacy === 'private') {
@@ -412,7 +422,8 @@ function handleMethods(analyzerMethods: Iterable<analyzer.Method>):
     const m = new ts.Method({
       name: method.name,
       returns: closureTypeToTypeScript(method.return && method.return.type),
-      returnsDescription: method.return && method.return.desc
+      returnsDescription: method.return && method.return.desc,
+      isStatic: opts && opts.isStatic,
     });
     m.description = method.description || '';
 

--- a/src/gen-ts.ts
+++ b/src/gen-ts.ts
@@ -278,25 +278,58 @@ function handleBehavior(feature: analyzer.PolymerBehavior, root: ts.Document) {
  * Add the given Mixin to the given TypeScript declarations document.
  */
 function handleMixin(feature: analyzer.ElementMixin, root: ts.Document) {
-  const [namespacePath, name] = splitReference(feature.name);
-  const namespace_ = findOrCreateNamespace(root, namespacePath);
+  const [namespacePath, mixinName] = splitReference(feature.name);
+  const parentNamespace = findOrCreateNamespace(root, namespacePath);
 
-  // We represent mixins in two parts: a mixin function that is called to
-  // augment a given class with this mixin, and an interface with the
-  // properties and methods that are added by this mixin. We can use the same
-  // name for both parts because one is in value space, and the other is in
-  // type space.
+  // The mixin function. It takes a constructor, and returns an intersection of
+  // 1) the given constructor, 2) the constructor for this mixin, 3) the
+  // constructors for any other mixins that this mixin also applies.
+  parentNamespace.members.push(new ts.Function({
+    name: mixinName,
+    description: feature.description,
+    templateTypes: ['T extends new (...args: any[]) => {}'],
+    params: [
+      new ts.Param({name: 'base', type: new ts.NameType('T')}),
+    ],
+    returns: new ts.IntersectionType([
+      new ts.NameType('T'),
+      new ts.NameType(mixinName + 'Constructor'),
+      ...feature.mixins.map(
+          (m) => new ts.NameType(m.identifier + 'Constructor'))
+    ]),
+  }));
 
-  const function_ = new ts.Mixin({name});
-  function_.description = feature.description;
-  function_.interfaces = [name, ...feature.mixins.map((m) => m.identifier)];
-  namespace_.members.push(function_);
+  // The interface for a constructor of this mixin. Returns the instance
+  // interface (see below) when instantiated, and may also have methods of its
+  // own (static methods from the mixin class).
+  parentNamespace.members.push(new ts.Interface({
+    name: mixinName + 'Constructor',
+    methods: [
+      new ts.Method({
+        name: 'new',
+        params: [
+          new ts.Param({
+            name: 'args',
+            type: new ts.ArrayType(ts.anyType),
+            rest: true,
+          }),
+        ],
+        returns: new ts.NameType(mixinName),
+      }),
+      ...handleMethods(feature.staticMethods.values()),
+    ],
+  }));
 
-  const interface_ = new ts.Interface({name});
-  interface_.properties = handleProperties(feature.properties.values());
-  interface_.methods = handleMethods(feature.methods.values());
-  namespace_.members.push(interface_);
-}
+  // The interface for instances of this mixin. Has the same name as the
+  // function.
+  parentNamespace.members.push(
+      new ts.Interface({
+        name: mixinName,
+        properties: handleProperties(feature.properties.values()),
+        methods: handleMethods(feature.methods.values()),
+      }),
+  );
+};
 
 /**
  * Add the given Class to the given TypeScript declarations document.

--- a/src/test/goldens/polymer/lib/elements/array-selector.d.ts
+++ b/src/test/goldens/polymer/lib/elements/array-selector.d.ts
@@ -14,6 +14,7 @@
 
 declare namespace Polymer {
 
+
   /**
    * Element mixin for recording dynamic associations between item paths in a
    * master `items` array and a `selected` array such that path changes to the
@@ -28,9 +29,11 @@ declare namespace Polymer {
    * representing the last selected item.  When `multi` is true, `selected`
    * is an array of multiply selected items.
    */
-  function ArraySelectorMixin<T extends new(...args: any[]) => {}>(base: T): {
-    new(...args: any[]): ArraySelectorMixin & Polymer.ElementMixin
-  } & T
+  function ArraySelectorMixin<T extends new (...args: any[]) => {}>(base: T): T & ArraySelectorMixinConstructor & Polymer.ElementMixinConstructor;
+
+  interface ArraySelectorMixinConstructor {
+    new(...args: any[]): ArraySelectorMixin;
+  }
 
   interface ArraySelectorMixin {
 

--- a/src/test/goldens/polymer/lib/elements/dom-module.d.ts
+++ b/src/test/goldens/polymer/lib/elements/dom-module.d.ts
@@ -33,7 +33,13 @@ declare namespace Polymer {
    *     let img = customElements.get('dom-module').import('foo', 'img');
    */
   class DomModule extends HTMLElement {
-    attributeChangedCallback(name: string, old: any, value: any): void;
+
+    /**
+     * @param name Name of attribute.
+     * @param old Old value of attribute.
+     * @param value Current value of attribute.
+     */
+    attributeChangedCallback(name: string, old: string|null, value: string|null): void;
 
     /**
      * Registers the dom-module at a given id. This method should only be called

--- a/src/test/goldens/polymer/lib/legacy/legacy-element-mixin.d.ts
+++ b/src/test/goldens/polymer/lib/legacy/legacy-element-mixin.d.ts
@@ -19,15 +19,18 @@
 
 declare namespace Polymer {
 
+
   /**
    * Element class mixin that provides Polymer's "legacy" API intended to be
    * backward-compatible to the greatest extent possible with the API
    * found on the Polymer 1.x `Polymer.Base` prototype applied to all elements
    * defined using the `Polymer({...})` function.
    */
-  function LegacyElementMixin<T extends new(...args: any[]) => {}>(base: T): {
-    new(...args: any[]): LegacyElementMixin & Polymer.ElementMixin & Polymer.GestureEventListeners
-  } & T
+  function LegacyElementMixin<T extends new (...args: any[]) => {}>(base: T): T & LegacyElementMixinConstructor & Polymer.ElementMixinConstructor & Polymer.GestureEventListenersConstructor;
+
+  interface LegacyElementMixinConstructor {
+    new(...args: any[]): LegacyElementMixin;
+  }
 
   interface LegacyElementMixin {
     isAttached: boolean;

--- a/src/test/goldens/polymer/lib/mixins/dir-mixin.d.ts
+++ b/src/test/goldens/polymer/lib/mixins/dir-mixin.d.ts
@@ -12,6 +12,7 @@
 
 declare namespace Polymer {
 
+
   /**
    * Element class mixin that allows elements to use the `:dir` CSS Selector to have
    * text direction specific styling.
@@ -28,9 +29,20 @@ declare namespace Polymer {
    * - Changing `dir` at runtime is supported.
    * - Opting out of the global direction styling is permanent
    */
-  function DirMixin<T extends new(...args: any[]) => {}>(base: T): {
-    new(...args: any[]): DirMixin & Polymer.PropertyAccessors
-  } & T
+  function DirMixin<T extends new (...args: any[]) => {}>(base: T): T & DirMixinConstructor & Polymer.PropertyAccessorsConstructor;
+
+  interface DirMixinConstructor {
+    new(...args: any[]): DirMixin;
+    _processStyleText(cssText: any, baseURI: any): any;
+
+    /**
+     * Replace `:dir` in the given CSS text
+     *
+     * @param text CSS text to replace DIR
+     * @returns Modified CSS
+     */
+    _replaceDirInCssText(text: string): string;
+  }
 
   interface DirMixin {
     ready(): any;

--- a/src/test/goldens/polymer/lib/mixins/element-mixin.d.ts
+++ b/src/test/goldens/polymer/lib/mixins/element-mixin.d.ts
@@ -19,6 +19,7 @@
 
 declare namespace Polymer {
 
+
   /**
    * Element class mixin that provides the core API for Polymer's meta-programming
    * features including template stamping, data-binding, attribute deserialization,
@@ -75,9 +76,61 @@ declare namespace Polymer {
    *   `observedAttributes` implementation will automatically return an array
    *   of dash-cased attributes based on `properties`)
    */
-  function ElementMixin<T extends new(...args: any[]) => {}>(base: T): {
-    new(...args: any[]): ElementMixin & Polymer.PropertyEffects & Polymer.PropertiesMixin
-  } & T
+  function ElementMixin<T extends new (...args: any[]) => {}>(base: T): T & ElementMixinConstructor & Polymer.PropertyEffectsConstructor & Polymer.PropertiesMixinConstructor;
+
+  interface ElementMixinConstructor {
+    new(...args: any[]): ElementMixin;
+
+    /**
+     * Overrides `PropertyAccessors` to add map of dynamic functions on
+     * template info, for consumption by `PropertyEffects` template binding
+     * code. This map determines which method templates should have accessors
+     * created for them.
+     */
+    _parseTemplateContent(template: any, templateInfo: any, nodeInfo: any): any;
+
+    /**
+     * Override of PropertiesChanged createProperties to create accessors
+     * and property effects for all of the properties.
+     */
+    createProperties(props: any): void;
+
+    /**
+     * Override of PropertiesMixin _finalizeClass to create observers and
+     * find the template.
+     */
+    _finalizeClass(): void;
+
+    /**
+     * Creates observers for the given `observers` array.
+     * Leverages `PropertyEffects` to create observers.
+     *
+     * @param observers Array of observer descriptors for
+     *   this class
+     * @param dynamicFns Object containing keys for any properties
+     *   that are functions and should trigger the effect when the function
+     *   reference is changed
+     */
+    createObservers(observers: object|null, dynamicFns: object|null): void;
+
+    /**
+     * Gather style text for a style element in the template.
+     *
+     * @param cssText Text containing styling to process
+     * @param baseURI Base URI to rebase CSS paths against
+     * @returns The processed CSS text
+     */
+    _processStyleText(cssText: string, baseURI: string): string;
+
+    /**
+     * Configures an element `proto` to function with a given `template`.
+     * The element name `is` and extends `ext` must be specified for ShadyCSS
+     * style scoping.
+     *
+     * @param is Tag name (or type extension name) for this element
+     */
+    _finalizeTemplate(is: string): void;
+  }
 
   interface ElementMixin {
     _template: HTMLTemplateElement|null;

--- a/src/test/goldens/polymer/lib/mixins/gesture-event-listeners.d.ts
+++ b/src/test/goldens/polymer/lib/mixins/gesture-event-listeners.d.ts
@@ -14,6 +14,7 @@
 
 declare namespace Polymer {
 
+
   /**
    * Element class mixin that provides API for adding Polymer's cross-platform
    * gesture events to nodes.
@@ -23,9 +24,11 @@ declare namespace Polymer {
    * templates will support gesture events when this mixin is applied along with
    * `Polymer.TemplateStamp`.
    */
-  function GestureEventListeners<T extends new(...args: any[]) => {}>(base: T): {
-    new(...args: any[]): GestureEventListeners
-  } & T
+  function GestureEventListeners<T extends new (...args: any[]) => {}>(base: T): T & GestureEventListenersConstructor;
+
+  interface GestureEventListenersConstructor {
+    new(...args: any[]): GestureEventListeners;
+  }
 
   interface GestureEventListeners {
     _addEventListenerToNode(node: any, eventName: any, handler: any): any;

--- a/src/test/goldens/polymer/lib/mixins/mutable-data.d.ts
+++ b/src/test/goldens/polymer/lib/mixins/mutable-data.d.ts
@@ -12,6 +12,7 @@
 
 declare namespace Polymer {
 
+
   /**
    * Element class mixin to skip strict dirty-checking for objects and arrays
    * (always consider them to be "dirty"), for use on elements utilizing
@@ -46,9 +47,11 @@ declare namespace Polymer {
    * will be worse as opposed to using strict dirty checking with immutable
    * patterns or Polymer's path notification API.
    */
-  function MutableData<T extends new(...args: any[]) => {}>(base: T): {
-    new(...args: any[]): MutableData
-  } & T
+  function MutableData<T extends new (...args: any[]) => {}>(base: T): T & MutableDataConstructor;
+
+  interface MutableDataConstructor {
+    new(...args: any[]): MutableData;
+  }
 
   interface MutableData {
 
@@ -70,6 +73,7 @@ declare namespace Polymer {
      */
     _shouldPropertyChange(property: string, value: any, old: any): boolean;
   }
+
 
   /**
    * Element class mixin to add the optional ability to skip strict
@@ -106,9 +110,11 @@ declare namespace Polymer {
    * strict dirty checking with immutable patterns or Polymer's path notification
    * API.
    */
-  function OptionalMutableData<T extends new(...args: any[]) => {}>(base: T): {
-    new(...args: any[]): OptionalMutableData
-  } & T
+  function OptionalMutableData<T extends new (...args: any[]) => {}>(base: T): T & OptionalMutableDataConstructor;
+
+  interface OptionalMutableDataConstructor {
+    new(...args: any[]): OptionalMutableData;
+  }
 
   interface OptionalMutableData {
 

--- a/src/test/goldens/polymer/lib/mixins/properties-changed.d.ts
+++ b/src/test/goldens/polymer/lib/mixins/properties-changed.d.ts
@@ -14,6 +14,7 @@
 
 declare namespace Polymer {
 
+
   /**
    * Element class mixin that provides basic meta-programming for creating one
    * or more property accessors (getter/setter pair) that enqueue an async
@@ -30,9 +31,36 @@ declare namespace Polymer {
    * deserialized via `attributeChangedCallback` and set to the associated
    * property using `dash-case`-to-`camelCase` convention.
    */
-  function PropertiesChanged<T extends new(...args: any[]) => {}>(base: T): {
-    new(...args: any[]): PropertiesChanged
-  } & T
+  function PropertiesChanged<T extends new (...args: any[]) => {}>(base: T): T & PropertiesChangedConstructor;
+
+  interface PropertiesChangedConstructor {
+    new(...args: any[]): PropertiesChanged;
+
+    /**
+     * Creates property accessors for the given property names.
+     *
+     * @param props Object whose keys are names of accessors.
+     */
+    createProperties(props: object|null): any;
+
+    /**
+     * Returns an attribute name that corresponds to the given property.
+     * The attribute name is the lowercased property name. Override to
+     * customize this mapping.
+     *
+     * @param property Property to convert
+     * @returns Attribute name corresponding to the given property.
+     */
+    attributeNameForProperty(property: string): string;
+
+    /**
+     * Override point to provide a type to which to deserialize a value to
+     * a given property.
+     *
+     * @param name Name of property
+     */
+    typeForProperty(name: string): any;
+  }
 
   interface PropertiesChanged {
 

--- a/src/test/goldens/polymer/lib/mixins/properties-mixin.d.ts
+++ b/src/test/goldens/polymer/lib/mixins/properties-mixin.d.ts
@@ -14,6 +14,7 @@
 
 declare namespace Polymer {
 
+
   /**
    * Mixin that provides a minimal starting point to using the PropertiesChanged
    * mixin by providing a mechanism to declare properties in a static
@@ -25,9 +26,35 @@ declare namespace Polymer {
    * way makes sense. This can be done in reaction to properties changing by
    * implementing `_propertiesChanged`.
    */
-  function PropertiesMixin<T extends new(...args: any[]) => {}>(base: T): {
-    new(...args: any[]): PropertiesMixin & Polymer.PropertiesChanged
-  } & T
+  function PropertiesMixin<T extends new (...args: any[]) => {}>(base: T): T & PropertiesMixinConstructor & Polymer.PropertiesChangedConstructor;
+
+  interface PropertiesMixinConstructor {
+    new(...args: any[]): PropertiesMixin;
+
+    /**
+     * Overrides `PropertiesChanged` method to return type specified in the
+     * static `properties` object for the given property.
+     *
+     * @param name Name of property
+     * @returns Type to which to deserialize attribute
+     */
+    typeForProperty(name: string): any;
+
+    /**
+     * Finalizes an element definition, including ensuring any super classes
+     * are also finalized. This includes ensuring property
+     * accessors exist on the element prototype. This method calls
+     * `_finalizeClass` to finalize each constructor in the prototype chain.
+     */
+    finalize(): any;
+
+    /**
+     * Finalize an element class. This includes ensuring property
+     * accessors exist on the element prototype. This method is called by
+     * `finalize` and finalizes the class constructor.
+     */
+    _finalizeClass(): any;
+  }
 
   interface PropertiesMixin {
 

--- a/src/test/goldens/polymer/lib/mixins/property-accessors.d.ts
+++ b/src/test/goldens/polymer/lib/mixins/property-accessors.d.ts
@@ -15,6 +15,7 @@
 
 declare namespace Polymer {
 
+
   /**
    * Element class mixin that provides basic meta-programming for creating one
    * or more property accessors (getter/setter pair) that enqueue an async
@@ -31,9 +32,29 @@ declare namespace Polymer {
    * deserialized via `attributeChangedCallback` and set to the associated
    * property using `dash-case`-to-`camelCase` convention.
    */
-  function PropertyAccessors<T extends new(...args: any[]) => {}>(base: T): {
-    new(...args: any[]): PropertyAccessors & Polymer.PropertiesChanged
-  } & T
+  function PropertyAccessors<T extends new (...args: any[]) => {}>(base: T): T & PropertyAccessorsConstructor & Polymer.PropertiesChangedConstructor;
+
+  interface PropertyAccessorsConstructor {
+    new(...args: any[]): PropertyAccessors;
+
+    /**
+     * Returns an attribute name that corresponds to the given property.
+     * By default, converts camel to dash case, e.g. `fooBar` to `foo-bar`.
+     *
+     * @param property Property to convert
+     * @returns Attribute name corresponding to the given property.
+     */
+    attributeNameForProperty(property: string): string;
+
+    /**
+     * Generates property accessors for all attributes in the standard
+     * static `observedAttributes` array.
+     *
+     * Attribute names are mapped to property names using the `dash-case` to
+     * `camelCase` convention
+     */
+    createPropertiesForAttributes(): void;
+  }
 
   interface PropertyAccessors {
 

--- a/src/test/goldens/polymer/lib/mixins/template-stamp.d.ts
+++ b/src/test/goldens/polymer/lib/mixins/template-stamp.d.ts
@@ -13,6 +13,7 @@
 
 declare namespace Polymer {
 
+
   /**
    * Element mixin that provides basic template parsing and stamping, including
    * the following template-related features for stamped templates:
@@ -22,9 +23,178 @@ declare namespace Polymer {
    * - Nested template content caching/removal and re-installation (performance
    *   optimization)
    */
-  function TemplateStamp<T extends new(...args: any[]) => {}>(base: T): {
-    new(...args: any[]): TemplateStamp
-  } & T
+  function TemplateStamp<T extends new (...args: any[]) => {}>(base: T): T & TemplateStampConstructor;
+
+  interface TemplateStampConstructor {
+    new(...args: any[]): TemplateStamp;
+
+    /**
+     * Scans a template to produce template metadata.
+     *
+     * Template-specific metadata are stored in the object returned, and node-
+     * specific metadata are stored in objects in its flattened `nodeInfoList`
+     * array.  Only nodes in the template that were parsed as nodes of
+     * interest contain an object in `nodeInfoList`.  Each `nodeInfo` object
+     * contains an `index` (`childNodes` index in parent) and optionally
+     * `parent`, which points to node info of its parent (including its index).
+     *
+     * The template metadata object returned from this method has the following
+     * structure (many fields optional):
+     *
+     * ```js
+     *   {
+     *     // Flattened list of node metadata (for nodes that generated metadata)
+     *     nodeInfoList: [
+     *       {
+     *         // `id` attribute for any nodes with id's for generating `$` map
+     *         id: {string},
+     *         // `on-event="handler"` metadata
+     *         events: [
+     *           {
+     *             name: {string},   // event name
+     *             value: {string},  // handler method name
+     *           }, ...
+     *         ],
+     *         // Notes when the template contained a `<slot>` for shady DOM
+     *         // optimization purposes
+     *         hasInsertionPoint: {boolean},
+     *         // For nested `<template>`` nodes, nested template metadata
+     *         templateInfo: {object}, // nested template metadata
+     *         // Metadata to allow efficient retrieval of instanced node
+     *         // corresponding to this metadata
+     *         parentInfo: {number},   // reference to parent nodeInfo>
+     *         parentIndex: {number},  // index in parent's `childNodes` collection
+     *         infoIndex: {number},    // index of this `nodeInfo` in `templateInfo.nodeInfoList`
+     *       },
+     *       ...
+     *     ],
+     *     // When true, the template had the `strip-whitespace` attribute
+     *     // or was nested in a template with that setting
+     *     stripWhitespace: {boolean},
+     *     // For nested templates, nested template content is moved into
+     *     // a document fragment stored here; this is an optimization to
+     *     // avoid the cost of nested template cloning
+     *     content: {DocumentFragment}
+     *   }
+     * ```
+     *
+     * This method kicks off a recursive treewalk as follows:
+     *
+     * ```
+     *    _parseTemplate <---------------------+
+     *      _parseTemplateContent              |
+     *        _parseTemplateNode  <------------|--+
+     *          _parseTemplateNestedTemplate --+  |
+     *          _parseTemplateChildNodes ---------+
+     *          _parseTemplateNodeAttributes
+     *            _parseTemplateNodeAttribute
+     *
+     * ```
+     *
+     * These methods may be overridden to add custom metadata about templates
+     * to either `templateInfo` or `nodeInfo`.
+     *
+     * Note that this method may be destructive to the template, in that
+     * e.g. event annotations may be removed after being noted in the
+     * template metadata.
+     *
+     * @param template Template to parse
+     * @param outerTemplateInfo Template metadata from the outer
+     *   template, for parsing nested templates
+     * @returns Parsed template metadata
+     */
+    _parseTemplate(template: HTMLTemplateElement, outerTemplateInfo?: TemplateInfo|null): TemplateInfo;
+    _parseTemplateContent(template: any, templateInfo: any, nodeInfo: any): any;
+
+    /**
+     * Parses template node and adds template and node metadata based on
+     * the current node, and its `childNodes` and `attributes`.
+     *
+     * This method may be overridden to add custom node or template specific
+     * metadata based on this node.
+     *
+     * @param node Node to parse
+     * @param templateInfo Template metadata for current template
+     * @param nodeInfo Node metadata for current template.
+     * @returns `true` if the visited node added node-specific
+     *   metadata to `nodeInfo`
+     */
+    _parseTemplateNode(node: Node|null, templateInfo: TemplateInfo, nodeInfo: NodeInfo): boolean;
+
+    /**
+     * Parses template child nodes for the given root node.
+     *
+     * This method also wraps whitelisted legacy template extensions
+     * (`is="dom-if"` and `is="dom-repeat"`) with their equivalent element
+     * wrappers, collapses text nodes, and strips whitespace from the template
+     * if the `templateInfo.stripWhitespace` setting was provided.
+     *
+     * @param root Root node whose `childNodes` will be parsed
+     * @param templateInfo Template metadata for current template
+     * @param nodeInfo Node metadata for current template.
+     */
+    _parseTemplateChildNodes(root: Node|null, templateInfo: TemplateInfo, nodeInfo: NodeInfo): void;
+
+    /**
+     * Parses template content for the given nested `<template>`.
+     *
+     * Nested template info is stored as `templateInfo` in the current node's
+     * `nodeInfo`. `template.content` is removed and stored in `templateInfo`.
+     * It will then be the responsibility of the host to set it back to the
+     * template and for users stamping nested templates to use the
+     * `_contentForTemplate` method to retrieve the content for this template
+     * (an optimization to avoid the cost of cloning nested template content).
+     *
+     * @param node Node to parse (a <template>)
+     * @param outerTemplateInfo Template metadata for current template
+     *   that includes the template `node`
+     * @param nodeInfo Node metadata for current template.
+     * @returns `true` if the visited node added node-specific
+     *   metadata to `nodeInfo`
+     */
+    _parseTemplateNestedTemplate(node: HTMLTemplateElement|null, outerTemplateInfo: TemplateInfo|null, nodeInfo: NodeInfo): boolean;
+
+    /**
+     * Parses template node attributes and adds node metadata to `nodeInfo`
+     * for nodes of interest.
+     *
+     * @param node Node to parse
+     * @param templateInfo Template metadata for current template
+     * @param nodeInfo Node metadata for current template.
+     * @returns `true` if the visited node added node-specific
+     *   metadata to `nodeInfo`
+     */
+    _parseTemplateNodeAttributes(node: Element|null, templateInfo: TemplateInfo|null, nodeInfo: NodeInfo|null): boolean;
+
+    /**
+     * Parses a single template node attribute and adds node metadata to
+     * `nodeInfo` for attributes of interest.
+     *
+     * This implementation adds metadata for `on-event="handler"` attributes
+     * and `id` attributes.
+     *
+     * @param node Node to parse
+     * @param templateInfo Template metadata for current template
+     * @param nodeInfo Node metadata for current template.
+     * @param name Attribute name
+     * @param value Attribute value
+     * @returns `true` if the visited node added node-specific
+     *   metadata to `nodeInfo`
+     */
+    _parseTemplateNodeAttribute(node: Element|null, templateInfo: TemplateInfo, nodeInfo: NodeInfo, name: string, value: string): boolean;
+
+    /**
+     * Returns the `content` document fragment for a given template.
+     *
+     * For nested templates, Polymer performs an optimization to cache nested
+     * template content to avoid the cost of cloning deeply nested templates.
+     * This method retrieves the cached content for a given template.
+     *
+     * @param template Template to retrieve `content` for
+     * @returns Content fragment
+     */
+    _contentForTemplate(template: HTMLTemplateElement|null): DocumentFragment|null;
+  }
 
   interface TemplateStamp {
 

--- a/src/test/goldens/polymer/lib/utils/debounce.d.ts
+++ b/src/test/goldens/polymer/lib/utils/debounce.d.ts
@@ -17,6 +17,38 @@ declare namespace Polymer {
   class Debouncer {
 
     /**
+     * Creates a debouncer if no debouncer is passed as a parameter
+     * or it cancels an active debouncer otherwise. The following
+     * example shows how a debouncer can be called multiple times within a
+     * microtask and "debounced" such that the provided callback function is
+     * called once. Add this method to a custom element:
+     *
+     * _debounceWork() {
+     *   this._debounceJob = Polymer.Debouncer.debounce(this._debounceJob,
+     *       Polymer.Async.microTask, () => {
+     *     this._doWork();
+     *   });
+     * }
+     *
+     * If the `_debounceWork` method is called multiple times within the same
+     * microtask, the `_doWork` function will be called only once at the next
+     * microtask checkpoint.
+     *
+     * Note: In testing it is often convenient to avoid asynchrony. To accomplish
+     * this with a debouncer, you can use `Polymer.enqueueDebouncer` and
+     * `Polymer.flush`. For example, extend the above example by adding
+     * `Polymer.enqueueDebouncer(this._debounceJob)` at the end of the
+     * `_debounceWork` method. Then in a test, call `Polymer.flush` to ensure
+     * the debouncer has completed.
+     *
+     * @param debouncer Debouncer object.
+     * @param asyncModule Object with Async interface
+     * @param callback Callback to run.
+     * @returns Returns a debouncer object.
+     */
+    static debounce(debouncer: Debouncer|null, asyncModule: AsyncModule, callback: () => any): Debouncer;
+
+    /**
      * Sets the scheduler; that is, a module with the Async interface,
      * a callback and optional arguments to be passed to the run function
      * from the async module.

--- a/src/test/goldens/polymer/lib/utils/flattened-nodes-observer.d.ts
+++ b/src/test/goldens/polymer/lib/utils/flattened-nodes-observer.d.ts
@@ -55,6 +55,20 @@ declare namespace Polymer {
   class FlattenedNodesObserver {
 
     /**
+     * Returns the list of flattened nodes for the given `node`.
+     * This list consists of a node's children and, for any children
+     * that are `<slot>` elements, the expanded flattened list of `assignedNodes`.
+     * For example, if the observed node has children `<a></a><slot></slot><b></b>`
+     * and the `<slot>` has one `<div>` assigned to it, then the flattened
+     * nodes list is `<a></a><div></div><b></b>`. If the `<slot>` has other
+     * `<slot>` elements assigned to it, these are flattened as well.
+     *
+     * @param node The node for which to return the list of flattened nodes.
+     * @returns The list of flattened nodes for the given `node`.
+     */
+    static getFlattenedNodes(node: HTMLElement|HTMLSlotElement|null): any[]|null;
+
+    /**
      * Activates an observer. This method is automatically called when
      * a `FlattenedNodesObserver` is created. It should only be called to
      * re-activate an observer that has been deactivated via the `disconnect` method.

--- a/src/ts-ast.ts
+++ b/src/ts-ast.ts
@@ -255,6 +255,7 @@ export abstract class FunctionLike {
   templateTypes: string[];
   returns: Type;
   returnsDescription: string;
+  isStatic: boolean;
 
   constructor(data: {
     name: string,
@@ -262,7 +263,8 @@ export abstract class FunctionLike {
     params?: Param[],
     templateTypes?: string[],
     returns?: Type,
-    returnsDescription?: string
+    returnsDescription?: string,
+    isStatic?: boolean,
   }) {
     this.name = data.name;
     this.description = data.description || '';
@@ -270,6 +272,7 @@ export abstract class FunctionLike {
     this.returns = data.returns || anyType;
     this.templateTypes = data.templateTypes || [];
     this.returnsDescription = data.returnsDescription || '';
+    this.isStatic = data.isStatic || false;
   }
 
   serialize(depth: number = 0): string {
@@ -297,10 +300,13 @@ export abstract class FunctionLike {
       out += '\n' + formatComment(combinedDescription, depth);
     }
 
+    out += i;
     if (depth === 0) {
       out += 'declare ';
     }
-    out += i;
+    if (this.kind === 'method' && this.isStatic) {
+      out += 'static ';
+    }
     if (this.kind === 'function') {
       out += 'function ';
     }


### PR DESCRIPTION
Static methods are now emitted for classes, elements, and mixins.

Classes and elements are straightforward.

Mixins are more complicated. To make static methods work, mixin functions now return an intersection of constructor interfaces, instead of returning a single constructor that returns an intersection of instance interfaces. This lets us then represent mixin methods as regular methods on each constructor interface. This is similar to what the TypeScript compiler itself does when generating declarations for mixins with static methods. The output looks like this:

```ts
function MyMixin<T>(base: T): T & MyMixinConstructor & OtherMixinConstructor;

interface MyMixinConstructor {
  new(...args: any[]): MyMixin;
  staticMethod();
}

interface MyMixin {
  instanceMethod();
}
```

You can play around with this pattern [on the playground here](https://www.typescriptlang.org/play/#src=declare%20function%20MixinA%3CT%3E(base%3A%20T)%3A%20T%20%26%20MixinA.Constructor%3B%0D%0A%0D%0Adeclare%20namespace%20MixinA%20%7B%0D%0A%20%20interface%20Constructor%20%7B%0D%0A%20%20%20%20new(...args%3A%20any%5B%5D)%3A%20Interface%3B%0D%0A%20%20%20%20mixinAStatic()%3B%0D%0A%20%20%7D%0D%0A%0D%0A%20%20interface%20Interface%20%7B%0D%0A%20%20%20%20mixinAInstance()%3B%0D%0A%20%20%7D%0D%0A%7D%0D%0A%0D%0Adeclare%20function%20MixinB%3CT%3E(base%3A%20T)%3A%20T%20%26%20MixinB.Constructor%20%26%20MixinA.Constructor%3B%0D%0A%0D%0Adeclare%20namespace%20MixinB%20%7B%0D%0A%20%20interface%20Constructor%20%7B%0D%0A%20%20%20%20new(...args%3A%20any%5B%5D)%3A%20Interface%3B%0D%0A%20%20%20%20mixinBStatic()%3B%0D%0A%20%20%7D%0D%0A%0D%0A%20%20interface%20Interface%20%7B%0D%0A%20%20%20%20mixinBInstance()%3B%0D%0A%20%20%7D%0D%0A%7D%0D%0A%0D%0Aclass%20MyConcrete%20extends%20MixinB(Object)%20%7B%0D%0A%20%20%20%20static%20myStatic()%20%7B%20return%200%20%7D%0D%0A%20%20%20%20myInstance()%20%7B%20return%201%20%7D%0D%0A%7D%0D%0A%0D%0AMyConcrete.mixinAStatic()%3B%0D%0AMyConcrete.mixinBStatic()%3B%0D%0AMyConcrete.myStatic()%3B%0D%0A%0D%0Aconst%20m%20%3D%20new%20MyConcrete()%3B%0D%0Am.mixinAInstance()%3B%0D%0Am.mixinBInstance()%3B%0D%0Am.myInstance()%3B).

Also removes the specialized `Mixin` AST class in favor of using a standard `Function` and adding a new `IntersectionType` class.

 - [x] CHANGELOG.md has been updated
