### PR TITLE
Support object index signatures.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Static methods are now supported on classes, elements, and mixins.
 - Add `renameTypes` config option, a map of renames to apply to named types that can be configured per-project.
 - Convert Closure `ITemplateArray` type to TypeScript `TemplateStringsArray`.
+- Support object index signatures (e.g. `Object<foo, bar>` maps to `{[key: foo]: bar}`).
 
 ## [0.3.1] - 2017-12-15
 - Convert Closure `Object` to TypeScript `object`.

--- a/src/test/goldens/polymer/lib/legacy/legacy-element-mixin.d.ts
+++ b/src/test/goldens/polymer/lib/legacy/legacy-element-mixin.d.ts
@@ -34,7 +34,7 @@ declare namespace Polymer {
 
   interface LegacyElementMixin {
     isAttached: boolean;
-    _debouncers: any;
+    _debouncers: {[key: string]: Function|null};
 
     /**
      * Overrides the default `Polymer.PropertyEffects` implementation to

--- a/src/test/goldens/polymer/lib/mixins/element-mixin.d.ts
+++ b/src/test/goldens/polymer/lib/mixins/element-mixin.d.ts
@@ -138,7 +138,7 @@ declare namespace Polymer {
     rootPath: string;
     importPath: string;
     root: StampedTemplate|HTMLElement|ShadowRoot|null;
-    $: any;
+    $: {[key: string]: Element};
 
     /**
      * Stamps the element template.

--- a/src/ts-ast.ts
+++ b/src/ts-ast.ts
@@ -416,7 +416,7 @@ export class Param {
 
 // A TypeScript type expression.
 export type Type = NameType|UnionType|ArrayType|FunctionType|ConstructorType|
-    RecordType|IntersectionType;
+    RecordType|IntersectionType|IndexableObjectType;
 
 // string, MyClass, null, undefined, any
 export class NameType {
@@ -654,6 +654,27 @@ export class IntersectionType {
 
   serialize(): string {
     return this.types.map((t) => t.serialize()).join(' & ');
+  }
+}
+
+export class IndexableObjectType {
+  readonly kind = 'indexableObject';
+  keyType: Type;
+  valueType: Type;
+
+  constructor(keyType: Type, valueType: Type) {
+    this.keyType = keyType;
+    this.valueType = valueType;
+  }
+
+  * traverse(): Iterable<Node> {
+    yield this.keyType;
+    yield this.valueType;
+    yield this;
+  }
+
+  serialize(): string {
+    return `{[key: ${this.keyType.serialize()}]: ${this.valueType.serialize()}}`
   }
 }
 


### PR DESCRIPTION
Closure `Object<foo, bar>` maps to TypeScript `{[key: foo]: bar}`.

 - [x] CHANGELOG.md has been updated
