### PR TITLE
Handle optional and rest parameters in function type expressions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Handle optional and rest parameters in function type expressions.
 
 ## [0.3.3] - 2017-12-18
 - Pin Analyzer version for upcoming major refactor.

--- a/src/test/closure-types_test.ts
+++ b/src/test/closure-types_test.ts
@@ -95,16 +95,25 @@ suite('closureTypeToTypeScript', () => {
     check('!Array<string|number>', 'Array<string|number>');
   });
 
-  test('function', () => {
+  test('function with no params', () => {
     check('function()', '() => any');
     check('!function()', '() => any');
     check('?function()', '(() => any)|null');
+    check('function(): void', '() => void');
+  });
 
+  test('function with simple params and return', () => {
     check(
         'function(string, number): boolean',
         '(p0: string, p1: number) => boolean');
+  });
 
-    check('function(): void', '() => void');
+  test('function with optional param', () => {
+    check('function(string=): void', '(p0?: string) => void');
+  });
+
+  test('function with rest param', () => {
+    check('function(...string): void', '(...p0: string[]) => void');
   });
 
   test('function object', () => {
@@ -138,7 +147,7 @@ suite('closureParamToTypeScript', () => {
       expectedType: string,
       expectedOptional: boolean,
       expectedRest: boolean) {
-    const actual = closureParamToTypeScript(closureType);
+    const actual = closureParamToTypeScript('dummyName', closureType);
     assert.equal(actual.type.serialize(), expectedType);
     assert.equal(actual.optional, expectedOptional);
     assert.equal(actual.rest, expectedRest);

--- a/src/test/serialize_test.ts
+++ b/src/test/serialize_test.ts
@@ -26,10 +26,10 @@ suite('serializeTsDeclarations', () => {
     });
     m.description = 'This is my function.\nIt has a multi-line description.';
     m.params = [
-      new ts.Param({name: 'param1', type: new ts.NameType('string')}),
-      new ts.Param(
+      new ts.ParamType({name: 'param1', type: new ts.NameType('string')}),
+      new ts.ParamType(
           {name: 'param2', type: new ts.NameType('any'), optional: true}),
-      new ts.Param({
+      new ts.ParamType({
         name: 'param3',
         type: new ts.ArrayType(new ts.NameType('number')),
         rest: true

--- a/src/ts-ast.ts
+++ b/src/ts-ast.ts
@@ -13,7 +13,7 @@
 // TODO Try to make serialization methods easier to read.
 
 export type Node =
-    Document|Namespace|Class|Interface|Function|Method|Type|ParamType|Property;
+    Document|Namespace|Class|Interface|Function|Method|Type|Property;
 
 export class Document {
   readonly kind = 'document';
@@ -251,7 +251,7 @@ export abstract class FunctionLike {
   kind: string;
   name: string;
   description: string;
-  params: Param[];
+  params: ParamType[];
   templateTypes: string[];
   returns: Type;
   returnsDescription: string;
@@ -260,7 +260,7 @@ export abstract class FunctionLike {
   constructor(data: {
     name: string,
     description?: string,
-    params?: Param[],
+    params?: ParamType[],
     templateTypes?: string[],
     returns?: Type,
     returnsDescription?: string,
@@ -373,50 +373,9 @@ export class Property {
   }
 }
 
-export class Param {
-  readonly kind = 'param';
-  name: string;
-  type: Type;
-  optional: boolean;
-  rest: boolean;
-  description: string;
-
-  constructor(data: {
-    name: string,
-    type: Type,
-    optional?: boolean,
-    rest?: boolean,
-    description?: string
-  }) {
-    this.name = data.name;
-    this.type = data.type || anyType;
-    this.optional = data.optional || false;
-    this.rest = data.rest || false;
-    this.description = data.description || '';
-  }
-
-  * traverse(): Iterable<Node> {
-    yield* this.type.traverse();
-    yield this;
-  }
-
-  serialize(): string {
-    let out = '';
-    if (this.rest) {
-      out += '...';
-    }
-    out += this.name;
-    if (this.optional) {
-      out += '?';
-    }
-    out += ': ' + this.type.serialize();
-    return out;
-  }
-}
-
 // A TypeScript type expression.
 export type Type = NameType|UnionType|ArrayType|FunctionType|ConstructorType|
-    RecordType|IntersectionType|IndexableObjectType;
+    RecordType|IntersectionType|IndexableObjectType|ParamType;
 
 // string, MyClass, null, undefined, any
 export class NameType {
@@ -599,20 +558,39 @@ export class ParamType {
   name: string;
   type: Type;
   optional: boolean;
+  rest: boolean;
+  description: string;
+
+  constructor(data: {
+    name: string,
+    type: Type,
+    optional?: boolean,
+    rest?: boolean,
+    description?: string
+  }) {
+    this.name = data.name;
+    this.type = data.type || anyType;
+    this.optional = data.optional || false;
+    this.rest = data.rest || false;
+    this.description = data.description || '';
+  }
 
   * traverse(): Iterable<Node> {
     yield* this.type.traverse();
     yield this;
   }
 
-  constructor(name: string, type: Type, optional: boolean = false) {
-    this.name = name;
-    this.type = type;
-    this.optional = optional;
-  }
-
-  serialize() {
-    return `${this.name}${this.optional ? '?' : ''}: ${this.type.serialize()}`;
+  serialize(): string {
+    let out = '';
+    if (this.rest) {
+      out += '...';
+    }
+    out += this.name;
+    if (this.optional) {
+      out += '?';
+    }
+    out += ': ' + this.type.serialize();
+    return out;
   }
 }
 


### PR DESCRIPTION
Previously we already handled optional and rest parameters in full blown functions (e.g. `function foo()`). However, we did not handle them in function type expressions, for example `@param {function(?foo):void} bar`.

The handling for full functions and function type expressions is now unified.

 - [x] CHANGELOG.md has been updated
