### PR TITLE
add support for parameterised types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Support parameterised types other than `Array` and `Object`, such as `Foo<T>`
 
 ## [0.3.5] - 2017-01-01
 - Properties are now emitted as `readonly` when applicable.

--- a/src/closure-types.ts
+++ b/src/closure-types.ts
@@ -240,7 +240,8 @@ function convertParameterizedType(
   }
   const types = node.applications.map((application) =>
     convert(application, templateTypes));
-  return new ts.ParameterizedType(node.expression.name, ...types);
+  const name = renameMap.get(node.expression.name) || node.expression.name;
+  return new ts.ParameterizedType(name, ...types);
 }
 
 function convertUnion(

--- a/src/closure-types.ts
+++ b/src/closure-types.ts
@@ -241,7 +241,7 @@ function convertParameterizedType(
   const types = node.applications.map((application) =>
     convert(application, templateTypes));
   const name = renameMap.get(node.expression.name) || node.expression.name;
-  return new ts.ParameterizedType(name, ...types);
+  return new ts.ParameterizedType(name, types);
 }
 
 function convertUnion(
@@ -317,8 +317,7 @@ function isParameterizedArray(node: doctrine.Type):
 
 function isParameterizedType(node: doctrine.Type):
     node is doctrine.type.TypeApplication {
-  return node.type === 'TypeApplication' &&
-      node.expression.type === 'NameExpression';
+  return node.type === 'TypeApplication';
 }
 
 function isBareArray(node: doctrine.Type):

--- a/src/closure-types.ts
+++ b/src/closure-types.ts
@@ -193,6 +193,14 @@ const renameMap = new Map<string, string>([
   ['ITemplateArray', 'TemplateStringsArray'],
 ]);
 
+/*
+ * As above but only applicable when parameterized (`Foo<T>`)
+ */
+const parameterizedRenameMap = new Map<string, string>([
+  ['HTMLCollection', 'HTMLCollectionOf'],
+  ['NodeList', 'NodeListOf'],
+]);
+
 /**
  * Return whether the given AST node is an expression that is nullable by
  * default in the Closure type system.
@@ -240,7 +248,9 @@ function convertParameterizedType(
   }
   const types = node.applications.map((application) =>
     convert(application, templateTypes));
-  const name = renameMap.get(node.expression.name) || node.expression.name;
+  const name = renameMap.get(node.expression.name) ||
+    parameterizedRenameMap.get(node.expression.name) ||
+    node.expression.name;
   return new ts.ParameterizedType(name, types);
 }
 

--- a/src/test/fixtures/custom/my-class.js
+++ b/src/test/fixtures/custom/my-class.js
@@ -47,4 +47,9 @@ class MyClass {
    * @returns {!MyParameterizedType<boolean>}
    */
   parameterized_return_type() { }
+
+  /**
+   * @returns {!Array<!NodeList<!Node>|!HTMLCollection<!HTMLElement>>}
+   */
+  renamed_collection_return_types() { }
 }

--- a/src/test/fixtures/custom/my-class.js
+++ b/src/test/fixtures/custom/my-class.js
@@ -1,3 +1,9 @@
+/**
+ * @template T
+ * @constructor
+ */
+function MyParameterizedType() {}
+
 class MyClass {
   no_params() { }
 
@@ -42,4 +48,9 @@ class MyClass {
   defaulted_and_optional_param(p1 = "foo", p2) { }
 
   defaulted_and_required_param(p1 = "foo", p2) { }
+
+  /**
+   * @returns {!MyParameterizedType<boolean>}
+   */
+  parameterized_return_type() { }
 }

--- a/src/test/fixtures/custom/my-class.js
+++ b/src/test/fixtures/custom/my-class.js
@@ -1,9 +1,3 @@
-/**
- * @template T
- * @constructor
- */
-function MyParameterizedType() {}
-
 class MyClass {
   no_params() { }
 

--- a/src/test/goldens/custom/my-class.d.ts
+++ b/src/test/goldens/custom/my-class.d.ts
@@ -21,4 +21,5 @@ declare class MyClass {
   defaulted_param(p1?: any): any;
   defaulted_and_optional_param(p1?: any, p2?: string): any;
   defaulted_and_required_param(p1: any|undefined, p2: any): any;
+  parameterized_return_type(): MyParameterizedType<boolean>;
 }

--- a/src/test/goldens/custom/my-class.d.ts
+++ b/src/test/goldens/custom/my-class.d.ts
@@ -22,4 +22,5 @@ declare class MyClass {
   defaulted_and_optional_param(p1?: any, p2?: string): any;
   defaulted_and_required_param(p1: any|undefined, p2: any): any;
   parameterized_return_type(): MyParameterizedType<boolean>;
+  renamed_collection_return_types(): Array<NodeListOf<Node>|HTMLCollectionOf<HTMLElement>>;
 }

--- a/src/ts-ast.ts
+++ b/src/ts-ast.ts
@@ -519,7 +519,7 @@ export class ParameterizedType {
   itemTypes: Type[];
   name: string;
 
-  constructor(name: string, ...itemTypes: Type[]) {
+  constructor(name: string, itemTypes: Type[]) {
     this.name = name;
     this.itemTypes = itemTypes;
   }

--- a/src/ts-ast.ts
+++ b/src/ts-ast.ts
@@ -386,7 +386,7 @@ export class Property {
 
 // A TypeScript type expression.
 export type Type = NameType|UnionType|ArrayType|FunctionType|ConstructorType|
-    RecordType|IntersectionType|IndexableObjectType|ParamType;
+    RecordType|IntersectionType|IndexableObjectType|ParamType|ParameterizedType;
 
 // string, MyClass, null, undefined, any
 export class NameType {
@@ -510,6 +510,30 @@ export class ArrayType {
       // complex types (e.g. arrays of arrays).
       return `Array<${this.itemType.serialize()}>`;
     }
+  }
+}
+
+// Foo<Bar>
+export class ParameterizedType {
+  readonly kind = 'parameterized';
+  itemTypes: Type[];
+  name: string;
+
+  constructor(name: string, ...itemTypes: Type[]) {
+    this.name = name;
+    this.itemTypes = itemTypes;
+  }
+
+  * traverse(): Iterable<Node> {
+    for (const itemType of this.itemTypes) {
+      yield* itemType.traverse();
+    }
+    yield this;
+  }
+
+  serialize(): string {
+    const types = this.itemTypes.map((t) => t.serialize());
+    return `${this.name}<${types.join(', ')}>`;
   }
 }
 


### PR DESCRIPTION
Fixes #58.
Fixes #59.

---

Just a quick fix.

Haven't really been in the generator much until now so if this is way off how it should be implemented, do let me know. Happy to discard it or redo it.

Is there a way we can default to `any` if we don't know the type? So if someone does `NonExistent<number>`, we would produce `any`? or should we just assume it exists?
  