### PR TITLE
The --outDir flag is now required on the CLI.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- The `--outDir` flag is now required when using the command line tool. Previously it would print all concatenated typings to `stdout`, which doesn't make much sense given that we emit multiple files.
 
 ## [0.3.6] - 2017-01-09
 - Support parameterized types other than `Array` and `Object`, such as `Foo<T>`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,8 +43,7 @@ const argDefs = [
   {
     name: 'outDir',
     type: String,
-    description:
-        'Type declarations output directory (default concatenated to stdout).',
+    description: 'Type declarations output directory (required).',
   },
 ];
 
@@ -70,6 +69,10 @@ async function run(argv: string[]) {
     return;
   }
 
+  if (!args.outDir) {
+    throw new Error('--outDir is required');
+  }
+
   if (!args.config) {
     const p = path.join(args.root, 'gen-tsd.json');
     if (await fsExtra.pathExists(p)) {
@@ -83,14 +86,8 @@ async function run(argv: string[]) {
   }
 
   const fileMap = await generateDeclarations(args.root, config);
-
-  if (args.outDir) {
-    console.log('Writing type declarations to ' + path.resolve(args.outDir));
-    await writeFileMap(args.outDir, fileMap);
-  } else {
-    const concatenated = [...fileMap.values()].join('\n');
-    process.stdout.write(concatenated);
-  }
+  console.log('Writing type declarations to ' + path.resolve(args.outDir));
+  await writeFileMap(args.outDir, fileMap);
 }
 
 async function writeFileMap(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -86,7 +86,7 @@ async function run(argv: string[]) {
   }
 
   const fileMap = await generateDeclarations(args.root, config);
-  console.log('Writing type declarations to ' + path.resolve(args.outDir));
+  console.log('Writing type declarations to', path.resolve(args.outDir));
   await writeFileMap(args.outDir, fileMap);
 }
 


### PR DESCRIPTION
Previously it would print all concatenated typings to `stdout`, which doesn't make much sense given that we emit multiple files.

 - [x] CHANGELOG.md has been updated
