### PR TITLE
Append "Element" to hybrid element generated interface names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 - Always parameterize `Promise`. In Closure `Promise` is valid, but in TypeScript this is invalid and must be `Promise<any>` instead.
 - Escape `*\` comment end sequences when formatting comments. These turn up in practice when an HTML comment embeds a JavaScript style block comment, like here: https://github.com/PolymerElements/paper-icon-button/blob/master/paper-icon-button.html#L51
+- Hybrid Polymer elements without a LHS assignment now have `Element` appended to their generated interface name, to match the behavior of the Closure Polymer Pass (https://github.com/google/closure-compiler/wiki/Polymer-Pass#element-type-names-for-1xhybrid-call-syntax). For example, `interface IronRequest` is now `interface IronRequestElement`.
 
 ## [1.0.0] - 2018-01-25
 - [BREAKING] The `--outDir` flag is now required when using the command line tool. Previously it would print all concatenated typings to `stdout`, which doesn't make much sense given that we emit multiple files.

--- a/src/gen-ts.ts
+++ b/src/gen-ts.ts
@@ -238,10 +238,16 @@ function handleElement(feature: analyzer.Element, root: ts.Document) {
     parent = findOrCreateNamespace(root, namespacePath);
 
   } else if (feature.tagName) {
+    // No `className` means this is an element defined by a call to the Polymer
+    // function without a LHS assignment. We'll follow the convention of the
+    // Closure Polymer Pass, and emit a global namespace interface called
+    // `FooBarElement` (given a `tagName` of `foo-bar`). More context here:
+    //
+    // https://github.com/google/closure-compiler/wiki/Polymer-Pass#element-type-names-for-1xhybrid-call-syntax
+    // https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/PolymerClassDefinition.java#L128
     constructable = false;
-    shortName = kebabToCamel(feature.tagName);
+    shortName = kebabToCamel(feature.tagName) + 'Element';
     fullName = shortName;
-    // We're going to pollute the global scope with an interface.
     parent = root;
 
   } else {

--- a/src/test/goldens/custom/my-element.d.ts
+++ b/src/test/goldens/custom/my-element.d.ts
@@ -15,9 +15,9 @@
  *
  *   /** More danger! *\/*\/
  */
-interface MyElement extends Polymer.Element {
+interface MyElementElement extends Polymer.Element {
 }
 
 interface HTMLElementTagNameMap {
-  "my-element": MyElement;
+  "my-element": MyElementElement;
 }

--- a/src/test/goldens/paper-button/paper-button.d.ts
+++ b/src/test/goldens/paper-button/paper-button.d.ts
@@ -78,7 +78,7 @@
  * `--paper-button-flat-keyboard-focus` | Mixin applied to a flat button after it's been focused using the keyboard | `{}`
  * `--paper-button-raised-keyboard-focus` | Mixin applied to a raised button after it's been focused using the keyboard | `{}`
  */
-interface PaperButton extends Polymer.Element, Polymer.PaperButtonBehavior {
+interface PaperButtonElement extends Polymer.Element, Polymer.PaperButtonBehavior {
 
   /**
    * If true, the button should be styled with a shadow.
@@ -88,5 +88,5 @@ interface PaperButton extends Polymer.Element, Polymer.PaperButtonBehavior {
 }
 
 interface HTMLElementTagNameMap {
-  "paper-button": PaperButton;
+  "paper-button": PaperButtonElement;
 }


### PR DESCRIPTION
Hybrid Polymer elements without a LHS assignment now have `Element` appended to their generated interface name, to match the behavior of the Closure Polymer Pass
(https://github.com/google/closure-compiler/wiki/Polymer-Pass#element-type-names-for-1xhybrid-call-syntax). For example, `interface IronRequest` is now `interface IronRequestElement`.

This is helpful because some Polymer elements have annotations that reference other Polymer elements using this style, such as https://github.com/PolymerElements/iron-ajax/blob/master/iron-ajax.html#L474 and https://github.com/PolymerElements/paper-behaviors/blob/master/paper-ripple-behavior.html#L114.

Part of #69

 - [x] CHANGELOG.md has been updated
