### PR TITLE
Add excludeIdentifiers option and behavior interfaces now extend their applied behaviors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 - Added `excludeIdentifiers` config option. Use this to skip emitting any declarations for some feature by its class name, etc.
 - Renamed `exclude` config option to `excludeFiles` to disambiguate it from `excludeIdentifiers`. `exclude` still works as before for backwards compatibility, but will be removed in the next major version.
+- Polymer behavior interfaces now extend any additional behaviors that they apply. This is done with an array of behavior objects as documented at https://www.polymer-project.org/1.0/docs/devguide/behaviors#extending.
 
 ## [1.0.1] - 2018-02-01
 - Always parameterize `Promise`. In Closure `Promise` is valid, but in TypeScript this is invalid and must be `Promise<any>` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+- Added `excludeIdentifiers` config option. Use this to skip emitting any declarations for some feature by its class name, etc.
+- Renamed `exclude` config option to `excludeFiles` to disambiguate it from `excludeIdentifiers`. `exclude` still works as before for backwards compatibility, but will be removed in the next major version.
 
 ## [1.0.1] - 2018-02-01
 - Always parameterize `Promise`. In Closure `Promise` is valid, but in TypeScript this is invalid and must be `Promise<any>` instead.

--- a/README.md
+++ b/README.md
@@ -83,10 +83,14 @@ publish.
 By default the `gen-tsd` command will read a file called `gen-tsd.json` in
 your root directory. It has the following options:
 
-* **`exclude`**`: string[]`
+* **`excludeFiles`**`: string[]`
 
   Skip source files whose paths match any of these glob patterns. If
   `undefined`, defaults to excluding directories ending in "test" or "demo".
+
+* **`excludeIdentifiers`**`: string[]`
+
+  Do not emit any declarations for features that have any of these identifiers.
 
 * **`removeReferences`**`: string[]`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -792,9 +792,9 @@
       }
     },
     "polymer-analyzer": {
-      "version": "3.0.0-pre.9",
-      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.0.0-pre.9.tgz",
-      "integrity": "sha512-yn1mcaRq9ufchMcsvC6DvVNWDUCyyyPoQkKuhbprWLiJ3ZTHJdzhZ2xhouk8aOkwVgj7xn8c3Ei3uh5/C6s5cw==",
+      "version": "3.0.0-pre.10",
+      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.0.0-pre.10.tgz",
+      "integrity": "sha1-9vCd15PdL0IomsAdoCb8q6ZfGYw=",
       "requires": {
         "@types/babel-generator": "6.25.1",
         "@types/babel-traverse": "6.25.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "escodegen": "^1.9.0",
     "fs-extra": "^5.0.0",
     "minimatch": "^3.0.4",
-    "polymer-analyzer": "=3.0.0-pre.9"
+    "polymer-analyzer": "=3.0.0-pre.10"
   },
   "devDependencies": {
     "@types/chai": "^4.0.4",

--- a/src/gen-ts.ts
+++ b/src/gen-ts.ts
@@ -362,6 +362,7 @@ function handleBehavior(feature: analyzer.PolymerBehavior, root: ts.Document) {
   ns.members.push(new ts.Interface({
     name: className,
     description: feature.description || feature.summary,
+    extends: feature.behaviorAssignments.map((b) => b.name),
     properties: handleProperties(feature.properties.values()),
     methods: handleMethods(feature.methods.values()),
   }));

--- a/src/test/fixtures/custom/gen-tsd.json
+++ b/src/test/fixtures/custom/gen-tsd.json
@@ -1,5 +1,8 @@
 {
-  "exclude": [
+  "excludeFiles": [
     "exclude-me.js"
+  ],
+  "excludeIdentifiers": [
+    "ExcludeThisClass"
   ]
 }

--- a/src/test/fixtures/custom/my-class.js
+++ b/src/test/fixtures/custom/my-class.js
@@ -53,3 +53,6 @@ class MyClass {
    */
   renamed_collection_return_types() { }
 }
+
+class ExcludeThisClass {
+}

--- a/src/test/goldens/paper-behaviors/paper-button-behavior.d.ts
+++ b/src/test/goldens/paper-behaviors/paper-button-behavior.d.ts
@@ -14,7 +14,7 @@
 
 declare namespace Polymer {
 
-  interface PaperButtonBehavior {
+  interface PaperButtonBehavior extends Polymer.IronButtonState, Polymer.IronControlState, Polymer.PaperRippleBehavior {
 
     /**
      * The z-depth of this element, from 0-5. Setting to 0 will remove the

--- a/src/test/goldens/paper-behaviors/paper-checked-element-behavior.d.ts
+++ b/src/test/goldens/paper-behaviors/paper-checked-element-behavior.d.ts
@@ -19,7 +19,7 @@ declare namespace Polymer {
    * that has a `checked` property similar to `Polymer.IronCheckedElementBehavior`
    * and is compatible with having a ripple effect.
    */
-  interface PaperCheckedElementBehavior {
+  interface PaperCheckedElementBehavior extends Polymer.PaperInkyFocusBehavior, Polymer.IronCheckedElementBehavior {
 
     /**
      * Synchronizes the element's `active` and `checked` state.

--- a/src/test/goldens/paper-behaviors/paper-inky-focus-behavior.d.ts
+++ b/src/test/goldens/paper-behaviors/paper-inky-focus-behavior.d.ts
@@ -17,7 +17,7 @@ declare namespace Polymer {
   /**
    * `Polymer.PaperInkyFocusBehavior` implements a ripple when the element has keyboard focus.
    */
-  interface PaperInkyFocusBehavior {
+  interface PaperInkyFocusBehavior extends Polymer.IronButtonState, Polymer.IronControlState, Polymer.PaperRippleBehavior {
     _createRipple(): any;
     _focusedChanged(receivedFocusFromKeyboard: any): any;
   }


### PR DESCRIPTION
- Added `excludeIdentifiers` config option. Use this to skip emitting any declarations for some feature by its class name, etc. See https://github.com/PolymerElements/paper-styles/pull/151/files#r165803743 for motivation.

- Renamed `exclude` config option to `excludeFiles` to disambiguate it from `excludeIdentifiers`. `exclude` still works as before for backwards compatibility, but will be removed in the next major version.

- Polymer behavior interfaces now extend any additional behaviors that they apply. This is done with an array of behavior objects as documented at https://www.polymer-project.org/1.0/docs/devguide/behaviors#extending. Fixes #80.

 - [x] CHANGELOG.md has been updated
