### PR TITLE
Add --deleteExisting command line flag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added `excludeIdentifiers` config option. Use this to skip emitting any declarations for some feature by its class name, etc.
 - Renamed `exclude` config option to `excludeFiles` to disambiguate it from `excludeIdentifiers`. `exclude` still works as before for backwards compatibility, but will be removed in the next major version.
 - Polymer behavior interfaces now extend any additional behaviors that they apply. This is done with an array of behavior objects as documented at https://www.polymer-project.org/1.0/docs/devguide/behaviors#extending.
+- Added `--deleteExisting` command line flag (default false) which recursively deletes all `.d.ts` files in the output directory before writing new typings, excluding `node_modules/` and `bower_components/`.
 
 ## [1.0.1] - 2018-02-01
 - Always parameterize `Promise`. In Closure `Promise` is valid, but in TypeScript this is invalid and must be `Promise<any>` instead.

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,12 @@
       "resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.3.tgz",
       "integrity": "sha1-6JLSk8ksnB0/mvcsFaVU+8fgiVo="
     },
+    "@types/events": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
+      "integrity": "sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw==",
+      "dev": true
+    },
     "@types/fs-extra": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.0.tgz",
@@ -75,11 +81,12 @@
       }
     },
     "@types/glob": {
-      "version": "5.0.33",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.33.tgz",
-      "integrity": "sha512-BcD4yyWz+qmCggaYMSFF0Xn7GkO6tgwm3Fh9Gxk/kQmEU3Z7flQTnVlMyKBUNvXXNTCCyjqK4XT4/2hLd1gQ2A==",
+      "version": "5.0.35",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.35.tgz",
+      "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
       "dev": true,
       "requires": {
+        "@types/events": "1.1.0",
         "@types/minimatch": "3.0.1",
         "@types/node": "6.0.88"
       }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/chai": "^4.0.4",
-    "@types/glob": "^5.0.33",
+    "@types/glob": "^5.0.35",
     "@types/mocha": "^2.2.43",
     "bower": "^1.8.2",
     "chai": "^4.1.2",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -54,8 +54,17 @@ const argDefs = [
   },
 ];
 
+interface args {
+  help?: boolean;
+  version?: boolean;
+  root: string;
+  config?: string;
+  outDir?: string;
+  deleteExisting?: boolean;
+}
+
 async function run(argv: string[]) {
-  const args = commandLineArgs(argDefs, {argv});
+  const args = commandLineArgs(argDefs, {argv}) as args;
 
   if (args.help) {
     console.log(commandLineUsage([


### PR DESCRIPTION
This flag recursively deletes all `.d.ts` files in the output directory before writing new typings, excluding `node_modules/` and `bower_components/`.

Previously we were just adding `rm -rf **.d.ts` to the `update-types` npm script in each repo, but I recently realized that:
- `**` in an npm script is very non-portable. Since the system shell is used, `**` may not actually recurse. It doesn't on Windows. Even with bash, it requires `shopt -s globstar` or else it is non-recursive, and this is not even available by default on macOS because it ships with bash 3, and `globstar` was added in 4.
- We were deleting `d.ts` files in `node_modules/` and `bower_components/` when we re-generated, which is obviously not the intention.

 - [x] CHANGELOG.md has been updated
