### PR TITLE
Don't delete typings files mentioned in addReferences.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 - Elements that are constructable (usually a call to the Polymer function whose result is assigned to some variable) can now have behaviors.
+- The `--deleteExisting` command line flag will no longer delete `.d.ts` files that are referenced as values in the `addReferences` config option, since such files are typically hand-written.
 
 ## [1.1.1] - 2018-02-05
 - Fix missing `glob` dependency.


### PR DESCRIPTION
If the addReferences option is being used, it's probably to add some manually
written typings. Since manually written typing files won't get re-generated,
we shouldn't delete them.

Fixes #86.

 - [x] CHANGELOG.md has been updated
