### PR TITLE
Mixin functions now include all mixins applied transitively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+- Mixin functions now include all of the additional mixins they automatically apply. Previously, only the immediately applied mixins were accounted for, but not ones that were applied transitively.
 
 ## [1.1.2] - 2018-02-08
 - Elements that are constructable (usually a call to the Polymer function whose result is assigned to some variable) can now have behaviors.

--- a/src/gen-ts.ts
+++ b/src/gen-ts.ts
@@ -457,8 +457,8 @@ function handleMixin(
 
 /**
  * Mixins can automatically apply other mixins, indicated by the @appliesMixin
- * annotation. However, since mixins may be applied transitively, to know the
- * full set of them we need to traverse down the tree.
+ * annotation. However, since those mixins may themselves apply other mixins, to
+ * know the full set of them we need to traverse down the tree.
  */
 function transitiveMixins(
     parentMixin: analyzer.ElementMixin,

--- a/src/gen-ts.ts
+++ b/src/gen-ts.ts
@@ -144,7 +144,11 @@ function analyzerToAst(
     });
     for (const analyzerDoc of analyzerDocs) {
       handleDocument(
-          analyzerDoc, tsDoc, rootDir, config.excludeIdentifiers || []);
+          analysis,
+          analyzerDoc,
+          tsDoc,
+          rootDir,
+          config.excludeIdentifiers || []);
     }
     for (const ref of tsDoc.referencePaths) {
       const resolvedRef = path.resolve(rootDir, path.dirname(tsDoc.path), ref);
@@ -217,6 +221,7 @@ interface MaybePrivate {
  * items in the given Polymer Analyzer document.
  */
 function handleDocument(
+    analysis: analyzer.Analysis,
     doc: analyzer.Document,
     root: ts.Document,
     rootDir: string,
@@ -233,7 +238,7 @@ function handleDocument(
     } else if (feature.kinds.has('behavior')) {
       handleBehavior(feature as analyzer.PolymerBehavior, root);
     } else if (feature.kinds.has('element-mixin')) {
-      handleMixin(feature as analyzer.ElementMixin, root);
+      handleMixin(feature as analyzer.ElementMixin, root, analysis);
     } else if (feature.kinds.has('class')) {
       handleClass(feature as analyzer.Class, root);
     } else if (feature.kinds.has('function')) {
@@ -393,7 +398,10 @@ function handleBehavior(feature: analyzer.PolymerBehavior, root: ts.Document) {
 /**
  * Add the given Mixin to the given TypeScript declarations document.
  */
-function handleMixin(feature: analyzer.ElementMixin, root: ts.Document) {
+function handleMixin(
+    feature: analyzer.ElementMixin,
+    root: ts.Document,
+    analysis: analyzer.Analysis) {
   const [namespacePath, mixinName] = splitReference(feature.name);
   const parentNamespace = findOrCreateNamespace(root, namespacePath);
 
@@ -410,8 +418,8 @@ function handleMixin(feature: analyzer.ElementMixin, root: ts.Document) {
     returns: new ts.IntersectionType([
       new ts.NameType('T'),
       new ts.NameType(mixinName + 'Constructor'),
-      ...feature.mixins.map(
-          (m) => new ts.NameType(m.identifier + 'Constructor'))
+      ...Array.from(transitiveMixins(feature, analysis))
+          .map((mixin) => new ts.NameType(mixin + 'Constructor'))
     ]),
   }));
 
@@ -446,6 +454,34 @@ function handleMixin(feature: analyzer.ElementMixin, root: ts.Document) {
       }),
   );
 };
+
+/**
+ * Mixins can automatically apply other mixins, indicated by the @appliesMixin
+ * annotation. However, since mixins may be applied transitively, to know the
+ * full set of them we need to traverse down the tree.
+ */
+function transitiveMixins(
+    parentMixin: analyzer.ElementMixin,
+    analysis: analyzer.Analysis,
+    result?: Set<string>): Set<string> {
+  if (result === undefined) {
+    result = new Set();
+  }
+  for (const childRef of parentMixin.mixins) {
+    result.add(childRef.identifier);
+    const childMixinSet =
+        analysis.getFeatures({id: childRef.identifier, kind: 'element-mixin'});
+    if (childMixinSet.size !== 1) {
+      console.error(
+          `Found ${childMixinSet.size} features for mixin ` +
+          `${childRef.identifier}, expected 1.`);
+      continue;
+    }
+    const childMixin = childMixinSet.values().next().value;
+    transitiveMixins(childMixin, analysis, result);
+  }
+  return result;
+}
 
 /**
  * Add the given Class to the given TypeScript declarations document.

--- a/src/test/goldens/polymer/lib/elements/array-selector.d.ts
+++ b/src/test/goldens/polymer/lib/elements/array-selector.d.ts
@@ -29,7 +29,7 @@ declare namespace Polymer {
    * representing the last selected item.  When `multi` is true, `selected`
    * is an array of multiply selected items.
    */
-  function ArraySelectorMixin<T extends new (...args: any[]) => {}>(base: T): T & ArraySelectorMixinConstructor & Polymer.ElementMixinConstructor;
+  function ArraySelectorMixin<T extends new (...args: any[]) => {}>(base: T): T & ArraySelectorMixinConstructor & Polymer.ElementMixinConstructor & Polymer.PropertyEffectsConstructor & Polymer.TemplateStampConstructor & Polymer.PropertyAccessorsConstructor & Polymer.PropertiesChangedConstructor & Polymer.PropertiesMixinConstructor;
 
   interface ArraySelectorMixinConstructor {
     new(...args: any[]): ArraySelectorMixin;

--- a/src/test/goldens/polymer/lib/legacy/legacy-element-mixin.d.ts
+++ b/src/test/goldens/polymer/lib/legacy/legacy-element-mixin.d.ts
@@ -26,7 +26,7 @@ declare namespace Polymer {
    * found on the Polymer 1.x `Polymer.Base` prototype applied to all elements
    * defined using the `Polymer({...})` function.
    */
-  function LegacyElementMixin<T extends new (...args: any[]) => {}>(base: T): T & LegacyElementMixinConstructor & Polymer.ElementMixinConstructor & Polymer.GestureEventListenersConstructor;
+  function LegacyElementMixin<T extends new (...args: any[]) => {}>(base: T): T & LegacyElementMixinConstructor & Polymer.ElementMixinConstructor & Polymer.PropertyEffectsConstructor & Polymer.TemplateStampConstructor & Polymer.PropertyAccessorsConstructor & Polymer.PropertiesChangedConstructor & Polymer.PropertiesMixinConstructor & Polymer.GestureEventListenersConstructor;
 
   interface LegacyElementMixinConstructor {
     new(...args: any[]): LegacyElementMixin;

--- a/src/test/goldens/polymer/lib/mixins/dir-mixin.d.ts
+++ b/src/test/goldens/polymer/lib/mixins/dir-mixin.d.ts
@@ -29,7 +29,7 @@ declare namespace Polymer {
    * - Changing `dir` at runtime is supported.
    * - Opting out of the global direction styling is permanent
    */
-  function DirMixin<T extends new (...args: any[]) => {}>(base: T): T & DirMixinConstructor & Polymer.PropertyAccessorsConstructor;
+  function DirMixin<T extends new (...args: any[]) => {}>(base: T): T & DirMixinConstructor & Polymer.PropertyAccessorsConstructor & Polymer.PropertiesChangedConstructor;
 
   interface DirMixinConstructor {
     new(...args: any[]): DirMixin;

--- a/src/test/goldens/polymer/lib/mixins/element-mixin.d.ts
+++ b/src/test/goldens/polymer/lib/mixins/element-mixin.d.ts
@@ -76,7 +76,7 @@ declare namespace Polymer {
    *   `observedAttributes` implementation will automatically return an array
    *   of dash-cased attributes based on `properties`)
    */
-  function ElementMixin<T extends new (...args: any[]) => {}>(base: T): T & ElementMixinConstructor & Polymer.PropertyEffectsConstructor & Polymer.PropertiesMixinConstructor;
+  function ElementMixin<T extends new (...args: any[]) => {}>(base: T): T & ElementMixinConstructor & Polymer.PropertyEffectsConstructor & Polymer.TemplateStampConstructor & Polymer.PropertyAccessorsConstructor & Polymer.PropertiesChangedConstructor & Polymer.PropertiesMixinConstructor;
 
   interface ElementMixinConstructor {
     new(...args: any[]): ElementMixin;

--- a/src/test/goldens/polymer/lib/mixins/property-effects.d.ts
+++ b/src/test/goldens/polymer/lib/mixins/property-effects.d.ts
@@ -46,7 +46,7 @@ declare namespace Polymer {
    * whereas the default when using `PropertyAccessors` standalone is to be
    * async by default.
    */
-  function PropertyEffects<T extends new (...args: any[]) => {}>(base: T): T & PropertyEffectsConstructor & Polymer.TemplateStampConstructor & Polymer.PropertyAccessorsConstructor;
+  function PropertyEffects<T extends new (...args: any[]) => {}>(base: T): T & PropertyEffectsConstructor & Polymer.TemplateStampConstructor & Polymer.PropertyAccessorsConstructor & Polymer.PropertiesChangedConstructor;
 
   interface PropertyEffectsConstructor {
     new(...args: any[]): PropertyEffects;


### PR DESCRIPTION
Previously, only the immediately applied mixins were accounted for, but not ones that were applied transitively.

Fixes https://github.com/Polymer/polymer/issues/5087

 - [x] CHANGELOG.md has been updated
