### PR TITLE
Fix Windows path handling by parsing file:// URLs correctly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+- Fix bad file path handling which broke Windows support.
 
 ## [1.2.1] - 2018-03-09
 - Fix bug where if a package name was a prefix of one of its dependencies (e.g.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "fs-extra": "^5.0.0",
     "glob": "^7.1.2",
     "minimatch": "^3.0.4",
-    "polymer-analyzer": "=3.0.0-pre.14"
+    "polymer-analyzer": "=3.0.0-pre.14",
+    "vscode-uri": "^1.0.3"
   },
   "devDependencies": {
     "@types/chai": "^4.0.4",

--- a/src/gen-ts.ts
+++ b/src/gen-ts.ts
@@ -13,7 +13,7 @@ import * as minimatch from 'minimatch';
 import * as path from 'path';
 import * as analyzer from 'polymer-analyzer';
 import {Function as AnalyzerFunction} from 'polymer-analyzer/lib/javascript/function';
-import * as url from 'url';
+import Uri from 'vscode-uri';
 
 import {closureParamToTypeScript, closureTypeToTypeScript} from './closure-types';
 import * as ts from './ts-ast';
@@ -183,11 +183,11 @@ function analyzerToAst(
  */
 function analyzerUrlToRelativePath(
     analyzerUrl: string, rootDir: string): string|undefined {
-  const parsed = url.parse(analyzerUrl);
-  if (parsed.protocol !== 'file:' || parsed.host || !parsed.path) {
+  const parsed = Uri.parse(analyzerUrl);
+  if (parsed.scheme !== 'file' || parsed.authority || !parsed.fsPath) {
     return undefined;
   }
-  return path.relative(rootDir, parsed.path);
+  return path.relative(rootDir, parsed.fsPath);
 }
 
 /**


### PR DESCRIPTION
Previously we were using `url.parse` and assuming `path` would be a valid file path. However this will not 1) unescape percent-encoded characters like the `:` in `c:`, or 2) remove the leading slash before Windows drive letters. The `vscode-uri` library does this correctly with its `fsPath` property.

Addresses #95 

 - [x] CHANGELOG.md has been updated
