### PR TITLE
Fix: Cross-Platform removal of lib directory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1035,6 +1035,15 @@
         "path-parse": "1.0.5"
       }
     },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
+    },
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -32,12 +32,13 @@
     "chai": "^4.1.2",
     "clang-format": "^1.1.0",
     "mocha": "^5.0.0",
+    "rimraf": "^2.6.2",
     "source-map-support": "^0.5.0",
     "tsc-then": "^1.0.1",
     "typescript": "^2.7.2"
   },
   "scripts": {
-    "clean": "rm -rf lib",
+    "clean": "rimraf lib",
     "format": "find src -name '*.ts' -not -path 'src/test/fixtures/*' -not -path 'src/test/goldens/*' | xargs clang-format --style=file -i",
     "build": "npm run clean && tsc",
     "build:watch": "tsc --watch",


### PR DESCRIPTION
This works with Cross-Platform to delete files instead of only Unix based.

Should be the last of #95 