### PR TITLE
Add support for class constructor types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
+- Generate typings for class constructors
 
 ## [1.2.2] - 2018-03-19
 - Fix bad file path handling which broke Windows support.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,12 +4,113 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0-beta.46",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.46.tgz",
+      "integrity": "sha512-7BKRkmYaPZm3Yff5HGZJKCz7RqZ5jUjknsXT6Gz5YKG23J3uq9hAj0epncCB0rlqmnZ8Q+UUpQB2tCR5mT37vw==",
+      "requires": {
+        "@babel/highlight": "7.0.0-beta.46"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.0.0-beta.46",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.46.tgz",
+      "integrity": "sha512-5VfaEVkPG0gpNSTcf70jvV+MjbMoNn4g2iluwM7MhciedkolEtmG7PcdoUj5W1EmMfngz5cF65V7UMZXJO6y8Q==",
+      "requires": {
+        "@babel/types": "7.0.0-beta.46",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.2.0",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.0.0-beta.46",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.46.tgz",
+      "integrity": "sha512-zm4Kc5XB2njGs8PkmjV1zE/g1hBuphbh+VcDyFLaQsxkxSFSUtCbKwFL8AQpL/qPIcGbvX1MBt50a/3ZZH2CQA==",
+      "requires": {
+        "@babel/helper-get-function-arity": "7.0.0-beta.46",
+        "@babel/template": "7.0.0-beta.46",
+        "@babel/types": "7.0.0-beta.46"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0-beta.46",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.46.tgz",
+      "integrity": "sha512-dPrTb7QHVx44xJLjUl3LGAc13iS7hdXdO0fiOxdRN1suIS91yGGgeuwiQBlrw5SxbFchYtwenhlKbqHdVfGyVA==",
+      "requires": {
+        "@babel/types": "7.0.0-beta.46"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.0.0-beta.46",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.46.tgz",
+      "integrity": "sha512-UT7acgV7wsnBPwnqslqcnUFvsPBP4TtVaYM82xPGA7+evAa8q8HXOmFk08qsMK/pX/yy4+51gJJwyw2zofnacA==",
+      "requires": {
+        "@babel/types": "7.0.0-beta.46"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0-beta.46",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.46.tgz",
+      "integrity": "sha512-r4snW6Q8ICL3Y8hGzYJRvyG/+sc+kvkewXNedG9tQjoHmUFMwMSv/o45GWQUQswevGnWghiGkpRPivFfOuMsOA==",
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.0"
+      }
+    },
+    "@babel/template": {
+      "version": "7.0.0-beta.46",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.46.tgz",
+      "integrity": "sha512-3/qi4m0l6G/vZbEwtqfzJk73mYtuE7nvAO1zT3/ZrTAHy4sHf2vaF9Eh1w+Tau263Yrkh0bjVQPb9zw6G+GeMQ==",
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.46",
+        "@babel/types": "7.0.0-beta.46",
+        "babylon": "7.0.0-beta.46",
+        "lodash": "^4.2.0"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.0.0-beta.46",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.46.tgz",
+      "integrity": "sha512-IU7MTGbcjpfhf5tyCu3sDB7sWYainZQcT+CqOBdVZXZfq5MMr130R7aiZBI2g5dJYUaW1PS81DVNpd0/Sq/Gzg==",
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.46",
+        "@babel/generator": "7.0.0-beta.46",
+        "@babel/helper-function-name": "7.0.0-beta.46",
+        "@babel/helper-split-export-declaration": "7.0.0-beta.46",
+        "@babel/types": "7.0.0-beta.46",
+        "babylon": "7.0.0-beta.46",
+        "debug": "^3.1.0",
+        "globals": "^11.1.0",
+        "invariant": "^2.2.0",
+        "lodash": "^4.2.0"
+      }
+    },
+    "@babel/types": {
+      "version": "7.0.0-beta.46",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.46.tgz",
+      "integrity": "sha512-uA5aruF2KKsJxToWdDpftsrPOIQtoGrGno2hiaeO9JRvfT9xZdK11nPoC+/RF9emNzmNbWn4HCRdCY+McT5Nbw==",
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.2.0",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
     "@types/babel-generator": {
       "version": "6.25.1",
       "resolved": "https://registry.npmjs.org/@types/babel-generator/-/babel-generator-6.25.1.tgz",
       "integrity": "sha512-nKNz9Ch4WP2TFZjQROhxqqS2SCk0OoDzGazJI6S+2sGgW9P7N4o3vluZAXFuPEnRqtz2A0vrrkK3tjQktxIlRw==",
       "requires": {
-        "@types/babel-types": "6.25.2"
+        "@types/babel-types": "*"
       }
     },
     "@types/babel-traverse": {
@@ -17,7 +118,7 @@
       "resolved": "https://registry.npmjs.org/@types/babel-traverse/-/babel-traverse-6.25.3.tgz",
       "integrity": "sha512-4FaulWyA7nrXPkzoukL2VmSpxCnBZwc+MgwZqO30gtHCrtaUXnoxymdYfxzf3CZN80zjtrVzKfLlZ7FPYvrhQQ==",
       "requires": {
-        "@types/babel-types": "6.25.2"
+        "@types/babel-types": "*"
       }
     },
     "@types/babel-types": {
@@ -30,7 +131,7 @@
       "resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.2.tgz",
       "integrity": "sha512-+Jty46mPaWe1VAyZbfvgJM4BAdklLWxrT5tc/RjvCgLrtk6gzRY6AOnoWFv4p6hVxhJshDdr2hGVn56alBp97Q==",
       "requires": {
-        "@types/babel-types": "6.25.2"
+        "@types/babel-types": "*"
       }
     },
     "@types/chai": {
@@ -43,7 +144,7 @@
       "resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.1.tgz",
       "integrity": "sha512-Aof+FLfWzBPzDgJ2uuBuPNOBHVx9Siyw4vmOcsMgsuxX1nfUWSlzpq4pdvQiaBgGjGS7vP/Oft5dpJbX4krT1A==",
       "requires": {
-        "@types/chai": "4.1.2"
+        "@types/chai": "*"
       }
     },
     "@types/chalk": {
@@ -76,7 +177,7 @@
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.1.tgz",
       "integrity": "sha512-h3wnflb+jMTipvbbZnClgA2BexrT4w0GcfoCz5qyxd0IRsbqhLSyesM6mqZTAnhbVmhyTm5tuxfRu9R+8l+lGw==",
       "requires": {
-        "@types/node": "9.4.7"
+        "@types/node": "*"
       }
     },
     "@types/glob": {
@@ -84,9 +185,9 @@
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.35.tgz",
       "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
       "requires": {
-        "@types/events": "1.2.0",
-        "@types/minimatch": "3.0.3",
-        "@types/node": "9.4.7"
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
       }
     },
     "@types/is-windows": {
@@ -115,23 +216,28 @@
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-2.2.34.tgz",
       "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
       "requires": {
-        "@types/node": "9.4.7"
+        "@types/node": "*"
       }
+    },
+    "@types/path-is-inside": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/path-is-inside/-/path-is-inside-1.0.0.tgz",
+      "integrity": "sha512-hfnXRGugz+McgX2jxyy5qz9sB21LRzlGn24zlwN2KEgoPtEvjzNRrLtUkOOebPDPZl3Rq7ywKxYvylVcEZDnEw=="
     },
     "@types/resolve": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.6.tgz",
       "integrity": "sha512-g+Rg8uMWY76oYTyaL+m7ZcblqF/oj7pE6uEUyACluJx4zcop1Lk14qQiocdEkEVMDFm6DmKpxJhsER+ZuTwG3g==",
       "requires": {
-        "@types/node": "9.4.7"
+        "@types/node": "*"
       }
     },
-    "@types/winston": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.3.8.tgz",
-      "integrity": "sha512-QqR0j08RCS1AQYPMRPHikEpcmK+2aEEbcSzWLwOqyJ4FhLmHUx/WjRrnn7tTQg/y4IKnMhzskh/o7qvGIZZ7iA==",
+    "@types/whatwg-url": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-6.4.0.tgz",
+      "integrity": "sha512-tonhlcbQ2eho09am6RHnHOgvtDfDYINd5rgxD+2YSkKENooVCFsWizJz139MQW/PV8FfClyKrNe9ZbdHrSCxGg==",
       "requires": {
-        "@types/node": "9.4.7"
+        "@types/node": "*"
       }
     },
     "ansi-regex": {
@@ -144,7 +250,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "requires": {
-        "color-convert": "1.9.1"
+        "color-convert": "^1.9.0"
       }
     },
     "argv-tools": {
@@ -152,8 +258,8 @@
       "resolved": "https://registry.npmjs.org/argv-tools/-/argv-tools-0.1.1.tgz",
       "integrity": "sha512-Cc0dBvx4dvrjjKpyDA6w8RlNAw8Su30NvZbWl/Tv9ZALEVlLVkWQiHMi84Q0xNfpVuSaiQbYkdmWK8g1PLGhKw==",
       "requires": {
-        "array-back": "2.0.0",
-        "find-replace": "2.0.1"
+        "array-back": "^2.0.0",
+        "find-replace": "^2.0.1"
       }
     },
     "array-back": {
@@ -161,7 +267,7 @@
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
       "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
       "requires": {
-        "typical": "2.6.1"
+        "typical": "^2.6.1"
       }
     },
     "assertion-error": {
@@ -170,152 +276,10 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
-    "async": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-      "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
-    },
-    "babel-code-frame": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-beta.3.tgz",
-      "integrity": "sha512-flMsJ9eSpShupt2Gwpka84DoMePvE4HlDObzdEc+1iNkacv3+NHlsJ7dMKmbnVA/AT22UhcGEBHwbJLoXWBO6Q==",
-      "requires": {
-        "chalk": "2.3.2",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
-      }
-    },
-    "babel-generator": {
-      "version": "6.26.1",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
-      "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.5",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
-      },
-      "dependencies": {
-        "babel-types": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.5",
-            "to-fast-properties": "1.0.3"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        }
-      }
-    },
-    "babel-helper-function-name": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-beta.3.tgz",
-      "integrity": "sha512-iMWYqwDarQOVlEGcK1MfbtK9vrFGs5Z4UQsdASJUHdhBp918EM5kndwriiIbhUX8gr2B/CEV/udJkFTrHsjdMQ==",
-      "requires": {
-        "babel-helper-get-function-arity": "7.0.0-beta.3",
-        "babel-template": "7.0.0-beta.3",
-        "babel-traverse": "7.0.0-beta.3",
-        "babel-types": "7.0.0-beta.3"
-      }
-    },
-    "babel-helper-get-function-arity": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-beta.3.tgz",
-      "integrity": "sha512-ZkYFRMWKx1c9fUW72YNM3eieBG701CMbLjmLLWmJTTPc0F0kddS9Fwok26EAmndUAgD6kFdh7ms3PH94MdGuGQ==",
-      "requires": {
-        "babel-types": "7.0.0-beta.3"
-      }
-    },
-    "babel-messages": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "requires": {
-        "core-js": "2.5.3",
-        "regenerator-runtime": "0.11.1"
-      }
-    },
-    "babel-template": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-7.0.0-beta.3.tgz",
-      "integrity": "sha512-urJduLja89kSDGqY8ryw8iIwQnMl30IvhMtMNmDD7vBX0l0oylaLgK+7df/9ODX9vR/PhXuif6HYl5HlzAKXMg==",
-      "requires": {
-        "babel-code-frame": "7.0.0-beta.3",
-        "babel-traverse": "7.0.0-beta.3",
-        "babel-types": "7.0.0-beta.3",
-        "babylon": "7.0.0-beta.27",
-        "lodash": "4.17.5"
-      },
-      "dependencies": {
-        "babylon": {
-          "version": "7.0.0-beta.27",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.27.tgz",
-          "integrity": "sha512-ksRx+r8eFIfdt63MCgLc9VxGL7W3jcyveQvMpNMVHgW+eb9mq3Xbm45FLCNkw8h92RvoNp4uuiwzcCEwxjDBZg=="
-        }
-      }
-    },
-    "babel-traverse": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-beta.3.tgz",
-      "integrity": "sha512-xyh/aPYuedMAfQlSj2kjHjsEmY5/Dpxs576L05DySAVMrV+ADX6l4mTOLysAEGwJfkePJlDLhFuS6SKaxv1V7w==",
-      "requires": {
-        "babel-code-frame": "7.0.0-beta.3",
-        "babel-helper-function-name": "7.0.0-beta.3",
-        "babel-types": "7.0.0-beta.3",
-        "babylon": "7.0.0-beta.27",
-        "debug": "3.1.0",
-        "globals": "10.4.0",
-        "invariant": "2.2.3",
-        "lodash": "4.17.5"
-      },
-      "dependencies": {
-        "babylon": {
-          "version": "7.0.0-beta.27",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.27.tgz",
-          "integrity": "sha512-ksRx+r8eFIfdt63MCgLc9VxGL7W3jcyveQvMpNMVHgW+eb9mq3Xbm45FLCNkw8h92RvoNp4uuiwzcCEwxjDBZg=="
-        }
-      }
-    },
-    "babel-types": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-beta.3.tgz",
-      "integrity": "sha512-36k8J+byAe181OmCMawGhw+DtKO7AwexPVtsPXoMfAkjtZgoCX3bEuHWfdE5sYxRM8dojvtG/+O08M0Z/YDC6w==",
-      "requires": {
-        "esutils": "2.0.2",
-        "lodash": "4.17.5",
-        "to-fast-properties": "2.0.0"
-      },
-      "dependencies": {
-        "to-fast-properties": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
-        }
-      }
-    },
     "babylon": {
-      "version": "7.0.0-beta.40",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
-      "integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg=="
+      "version": "7.0.0-beta.46",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.46.tgz",
+      "integrity": "sha512-WFJlg2WatdkXRFMpk7BN/Uzzkjkcjk+WaqnrSCpay+RYl4ypW9ZetZyT9kNt22IH/BQNst3M6PaaBn9IXsUNrg=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -333,7 +297,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -348,7 +312,7 @@
       "resolved": "https://registry.npmjs.org/cancel-token/-/cancel-token-0.1.1.tgz",
       "integrity": "sha1-wYGXZ0uxyEwdaTPr8V2NWlznm08=",
       "requires": {
-        "@types/node": "4.2.23"
+        "@types/node": "^4.0.30"
       },
       "dependencies": {
         "@types/node": {
@@ -364,12 +328,12 @@
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.1.0",
-        "check-error": "1.0.2",
-        "deep-eql": "3.0.1",
-        "get-func-name": "2.0.0",
-        "pathval": "1.1.0",
-        "type-detect": "4.0.8"
+        "assertion-error": "^1.0.1",
+        "check-error": "^1.0.1",
+        "deep-eql": "^3.0.0",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.0.0",
+        "type-detect": "^4.0.0"
       }
     },
     "chalk": {
@@ -377,9 +341,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
       "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.3.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "check-error": {
@@ -394,9 +358,9 @@
       "integrity": "sha512-6X9u1JBMak/9VbC0IZajEDvp19/PbjCanbRO3Z2xsluypQtbPPAGDvGGovLOWoUpXIvJH9vJExmzlqWvwItZxA==",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "glob": "7.1.2",
-        "resolve": "1.5.0"
+        "async": "^1.5.2",
+        "glob": "^7.0.0",
+        "resolve": "^1.1.6"
       },
       "dependencies": {
         "async": {
@@ -417,7 +381,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -425,21 +389,16 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
-    "colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
-    },
     "command-line-args": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.0.2.tgz",
       "integrity": "sha512-/qPcbL8zpqg53x4rAaqMFlRV4opN3pbla7I7k9x8kyOBMQoGT6WltjN6sXZuxOXw6DgdK7Ad+ijYS5gjcr7vlA==",
       "requires": {
-        "argv-tools": "0.1.1",
-        "array-back": "2.0.0",
-        "find-replace": "2.0.1",
-        "lodash.camelcase": "4.3.0",
-        "typical": "2.6.1"
+        "argv-tools": "^0.1.1",
+        "array-back": "^2.0.0",
+        "find-replace": "^2.0.1",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^2.6.1"
       }
     },
     "command-line-usage": {
@@ -447,10 +406,10 @@
       "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-5.0.2.tgz",
       "integrity": "sha512-hICrJJ5zUI7hnEBBluE2169CG3Xnn4D5HPeLkMjbiOyneSLTUX5Wz1d4FSi3xALUtzulIBStSt0S2tLXs8eVrg==",
       "requires": {
-        "array-back": "2.0.0",
-        "chalk": "2.3.2",
-        "table-layout": "0.4.2",
-        "typical": "2.6.1"
+        "array-back": "^2.0.0",
+        "chalk": "^2.3.2",
+        "table-layout": "^0.4.2",
+        "typical": "^2.6.1"
       }
     },
     "commander": {
@@ -464,20 +423,10 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
-    "core-js": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
-    },
     "cssbeautify": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cssbeautify/-/cssbeautify-0.3.1.tgz",
       "integrity": "sha1-Et0fc0A1wub6ymfcvc73TkKBE5c="
-    },
-    "cycle": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
     },
     "debug": {
       "version": "3.1.0",
@@ -493,7 +442,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "4.0.8"
+        "type-detect": "^4.0.0"
       }
     },
     "deep-extend": {
@@ -506,14 +455,6 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
-    "detect-indent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "requires": {
-        "repeating": "2.0.1"
-      }
-    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -525,7 +466,7 @@
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "requires": {
-        "esutils": "2.0.2"
+        "esutils": "^2.0.2"
       }
     },
     "dom5": {
@@ -533,9 +474,9 @@
       "resolved": "https://registry.npmjs.org/dom5/-/dom5-3.0.0.tgz",
       "integrity": "sha512-PbE+7C4Sh1dHDTLNuSDaMUGD1ivDiSZw0L+a9xVUzUKeQ8w3vdzfKHRA07CxcrFZZOa1SGl2nIJ9T49j63q+bg==",
       "requires": {
-        "@types/parse5": "2.2.34",
-        "clone": "2.1.1",
-        "parse5": "4.0.0"
+        "@types/parse5": "^2.2.32",
+        "clone": "^2.1.0",
+        "parse5": "^4.0.0"
       }
     },
     "escape-string-regexp": {
@@ -548,11 +489,11 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
       "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
       "requires": {
-        "esprima": "3.1.3",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.6.1"
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       }
     },
     "esprima": {
@@ -570,11 +511,6 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
-    "eyes": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
-    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -585,8 +521,8 @@
       "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-2.0.1.tgz",
       "integrity": "sha512-LzDo3Fpa30FLIBsh6DCDnMN1KW2g4QKkqKmejlImgWY67dDFPX/x9Kh/op/GK522DchQXEvDi/wD48HKW49XOQ==",
       "requires": {
-        "array-back": "2.0.0",
-        "test-value": "3.0.0"
+        "array-back": "^2.0.0",
+        "test-value": "^3.0.0"
       }
     },
     "fs-extra": {
@@ -594,9 +530,9 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
       "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "4.0.0",
-        "universalify": "0.1.1"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs.realpath": {
@@ -615,18 +551,18 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "globals": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-10.4.0.tgz",
-      "integrity": "sha512-uNUtxIZpGyuaq+5BqGGQHsL4wUlJAXRqOm6g3Y48/CWNGTLONgBibI0lh6lGxjR2HljFYUfszb+mk4WkgMntsA=="
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.5.0.tgz",
+      "integrity": "sha512-hYyf+kI8dm3nORsiiXUQigOU62hDLfJ9G01uyGMxhc6BKsircrUhC4uJPQPUSuq2GrTmiiEt7ewxlMdBewfmKQ=="
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -644,7 +580,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -668,8 +604,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -678,19 +614,11 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "invariant": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
-      "integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "requires": {
-        "loose-envify": "1.3.1"
-      }
-    },
-    "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "requires": {
-        "number-is-nan": "1.0.1"
+        "loose-envify": "^1.0.0"
       }
     },
     "is-windows": {
@@ -698,47 +626,42 @@
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
     },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "jsesc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+      "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
     },
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonschema": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.2.tgz",
-      "integrity": "sha512-iX5OFQ6yx9NgbHCwse51ohhKgLuLL7Z5cNOeZOPIlDUtAMrxlruHLzVZxbltdHE5mEDXN+75oFOwq6Gn0MZwsA=="
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
+      "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
     },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "lodash": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -760,7 +683,7 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "requires": {
-        "js-tokens": "3.0.2"
+        "js-tokens": "^3.0.0"
       }
     },
     "minimatch": {
@@ -768,15 +691,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.11"
-      }
-    },
-    "minimatch-all": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/minimatch-all/-/minimatch-all-1.1.0.tgz",
-      "integrity": "sha1-QMSWonouEo0Zv3WOdrsBoMcUV4c=",
-      "requires": {
-        "minimatch": "3.0.4"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -824,7 +739,7 @@
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -834,17 +749,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "optionator": {
@@ -852,12 +762,12 @@
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "parse5": {
@@ -886,65 +796,49 @@
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
-    "plylog": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/plylog/-/plylog-0.5.0.tgz",
-      "integrity": "sha1-yXbrodgNLdmRAF18EQ2vh0FUeI8=",
-      "requires": {
-        "@types/node": "4.2.23",
-        "@types/winston": "2.3.8",
-        "winston": "2.4.1"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "4.2.23",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-4.2.23.tgz",
-          "integrity": "sha512-U6IchCNLRyswc9p6G6lxWlbE+KwAhZp6mGo6MD2yWpmFomhYmetK+c98OpKyvphNn04CU3aXeJrXdOqbXVTS/w=="
-        }
-      }
-    },
     "polymer-analyzer": {
-      "version": "3.0.0-pre.14",
-      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.0.0-pre.14.tgz",
-      "integrity": "sha512-1Zh/smUWMrjBB7NFUk8i7EAnjO81PqhI0/RzMMy9VgAbPQ6jOROwFX71T02CgpkZYa0O66Ybl7G3+4+0S1aF1Q==",
+      "version": "3.0.0-pre.25",
+      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.0.0-pre.25.tgz",
+      "integrity": "sha512-jbpIHLQJPfhiZ/1urHfsjG3o8XYGtqRalpoMGtY95wijeGWHkpSS3x92tHiHUsYlqcIeQXCwimiBv0rnr+2n3Q==",
       "requires": {
-        "@types/babel-generator": "6.25.1",
-        "@types/babel-traverse": "6.25.3",
-        "@types/babel-types": "6.25.2",
-        "@types/babylon": "6.16.2",
-        "@types/chai-subset": "1.3.1",
-        "@types/chalk": "0.4.31",
-        "@types/clone": "0.1.30",
-        "@types/cssbeautify": "0.3.1",
-        "@types/doctrine": "0.0.1",
-        "@types/is-windows": "0.2.0",
-        "@types/minimatch": "3.0.3",
-        "@types/node": "6.0.102",
-        "@types/parse5": "2.2.34",
+        "@babel/generator": "^7.0.0-beta.42",
+        "@babel/traverse": "^7.0.0-beta.42",
+        "@babel/types": "^7.0.0-beta.42",
+        "@types/babel-generator": "^6.25.1",
+        "@types/babel-traverse": "^6.25.2",
+        "@types/babel-types": "^6.25.1",
+        "@types/babylon": "^6.16.2",
+        "@types/chai-subset": "^1.3.0",
+        "@types/chalk": "^0.4.30",
+        "@types/clone": "^0.1.30",
+        "@types/cssbeautify": "^0.3.1",
+        "@types/doctrine": "^0.0.1",
+        "@types/is-windows": "^0.2.0",
+        "@types/minimatch": "^3.0.1",
+        "@types/node": "^9.6.4",
+        "@types/parse5": "^2.2.34",
+        "@types/path-is-inside": "^1.0.0",
         "@types/resolve": "0.0.6",
-        "babel-generator": "6.26.1",
-        "babel-traverse": "7.0.0-beta.3",
-        "babel-types": "7.0.0-beta.3",
-        "babylon": "7.0.0-beta.40",
-        "cancel-token": "0.1.1",
-        "chalk": "1.1.3",
-        "clone": "2.1.1",
-        "cssbeautify": "0.3.1",
-        "doctrine": "2.1.0",
-        "dom5": "3.0.0",
+        "@types/whatwg-url": "^6.4.0",
+        "babylon": "^7.0.0-beta.42",
+        "cancel-token": "^0.1.1",
+        "chalk": "^1.1.3",
+        "clone": "^2.0.0",
+        "cssbeautify": "^0.3.1",
+        "doctrine": "^2.0.2",
+        "dom5": "^3.0.0",
         "indent": "0.0.2",
-        "is-windows": "1.0.2",
-        "jsonschema": "1.2.2",
-        "minimatch": "3.0.4",
-        "parse5": "4.0.0",
-        "path-is-inside": "1.0.2",
-        "polymer-project-config": "3.9.0",
-        "resolve": "1.5.0",
-        "shady-css-parser": "0.1.0",
-        "stable": "0.1.6",
-        "strip-indent": "2.0.0",
-        "vscode-uri": "1.0.3",
-        "whatwg-url": "6.4.0"
+        "is-windows": "^1.0.2",
+        "jsonschema": "^1.1.0",
+        "minimatch": "^3.0.4",
+        "parse5": "^4.0.0",
+        "path-is-inside": "^1.0.2",
+        "resolve": "^1.5.0",
+        "shady-css-parser": "^0.1.0",
+        "stable": "^0.1.6",
+        "strip-indent": "^2.0.0",
+        "vscode-uri": "^1.0.1",
+        "whatwg-url": "^6.4.0"
       },
       "dependencies": {
         "@types/doctrine": {
@@ -953,9 +847,9 @@
           "integrity": "sha1-uZny2fe0PKvgoaLzm8IDvH3K2p0="
         },
         "@types/node": {
-          "version": "6.0.102",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.102.tgz",
-          "integrity": "sha512-EhNufyBoC1Kqaj+XMHGzi6mPUC8wVABOMTPE5XaSJc49LIVvXsyrV1HYMAPTUViT7E4wLUB38OdDmb+HshjGmA=="
+          "version": "9.6.12",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.12.tgz",
+          "integrity": "sha512-2Z8ziWjJbvV8hHL5YcqCG9ng+/qwUlO1gB4frBD7QI5Wm1Y1iM+AEkGVEv0S5P+aDMwTtAhPJFR4rp1uqagSig=="
         },
         "ansi-styles": {
           "version": "2.2.1",
@@ -967,35 +861,17 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
-      }
-    },
-    "polymer-project-config": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-3.9.0.tgz",
-      "integrity": "sha512-WPOqlV2W/M4Ni40QIqYSv8PE7H4rjiPm1KEf02QPtjZOGlAC4Rv7e6UJ1Ke1O70WT5bydcsEn3LViFIqYpVOJw==",
-      "requires": {
-        "@types/node": "6.0.102",
-        "jsonschema": "1.2.2",
-        "minimatch-all": "1.1.0",
-        "plylog": "0.5.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "6.0.102",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.102.tgz",
-          "integrity": "sha512-EhNufyBoC1Kqaj+XMHGzi6mPUC8wVABOMTPE5XaSJc49LIVvXsyrV1HYMAPTUViT7E4wLUB38OdDmb+HshjGmA=="
         }
       }
     },
@@ -1014,25 +890,12 @@
       "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
       "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc="
     },
-    "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-    },
-    "repeating": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "requires": {
-        "is-finite": "1.0.2"
-      }
-    },
     "resolve": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "rimraf": {
@@ -1041,7 +904,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "semver": {
@@ -1066,25 +929,20 @@
       "integrity": "sha512-eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==",
       "dev": true,
       "requires": {
-        "source-map": "0.6.1"
+        "source-map": "^0.6.0"
       }
     },
     "stable": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.6.tgz",
-      "integrity": "sha1-kQ9dKu17Ugxud3SZwfMuE5/eyxA="
-    },
-    "stack-trace": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
     },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-indent": {
@@ -1097,7 +955,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
       "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "table-layout": {
@@ -1105,11 +963,11 @@
       "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.2.tgz",
       "integrity": "sha512-tygyl5+eSHj4chpq5Zfy6cpc7MOUBClAW9ozghFH7hg9bAUzShOYn+/vUzTRkKOSLJWKfgYtP2tAU2c0oAD8eg==",
       "requires": {
-        "array-back": "2.0.0",
-        "deep-extend": "0.5.0",
-        "lodash.padend": "4.6.1",
-        "typical": "2.6.1",
-        "wordwrapjs": "3.0.0"
+        "array-back": "^2.0.0",
+        "deep-extend": "~0.5.0",
+        "lodash.padend": "^4.6.1",
+        "typical": "^2.6.1",
+        "wordwrapjs": "^3.0.0"
       }
     },
     "test-value": {
@@ -1117,21 +975,21 @@
       "resolved": "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
       "integrity": "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==",
       "requires": {
-        "array-back": "2.0.0",
-        "typical": "2.6.1"
+        "array-back": "^2.0.0",
+        "typical": "^2.6.1"
       }
     },
     "to-fast-properties": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "tr46": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "requires": {
-        "punycode": "2.1.0"
+        "punycode": "^2.1.0"
       }
     },
     "trim-right": {
@@ -1145,8 +1003,8 @@
       "integrity": "sha512-830G8SK8tewOxfKVBC5YWqZ2C7wS1D4dh9267ebLxR7Gvh3UuI6aKU5Hxo+L3Kkcy6CuxZp4PMGl066DZ3Hlmw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.9.5",
-        "semver": "5.5.0"
+        "@types/node": "^8.0.53",
+        "semver": "^5.4.1"
       },
       "dependencies": {
         "@types/node": {
@@ -1162,7 +1020,7 @@
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
@@ -1198,26 +1056,13 @@
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
     },
     "whatwg-url": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
-      "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.1.tgz",
+      "integrity": "sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==",
       "requires": {
-        "lodash.sortby": "4.7.0",
-        "tr46": "1.0.1",
-        "webidl-conversions": "4.0.2"
-      }
-    },
-    "winston": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.1.tgz",
-      "integrity": "sha512-k/+Dkzd39ZdyJHYkuaYmf4ff+7j+sCIy73UCOWHYA67/WXU+FF/Y6PF28j+Vy7qNRPHWO+dR+/+zkoQWPimPqg==",
-      "requires": {
-        "async": "1.0.0",
-        "colors": "1.0.3",
-        "cycle": "1.0.3",
-        "eyes": "0.1.8",
-        "isstream": "0.1.2",
-        "stack-trace": "0.0.10"
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
       }
     },
     "wordwrap": {
@@ -1230,8 +1075,8 @@
       "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
       "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
       "requires": {
-        "reduce-flatten": "1.0.1",
-        "typical": "2.6.1"
+        "reduce-flatten": "^1.0.1",
+        "typical": "^2.6.1"
       }
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "fs-extra": "^5.0.0",
     "glob": "^7.1.2",
     "minimatch": "^3.0.4",
-    "polymer-analyzer": "=3.0.0-pre.24",
+    "polymer-analyzer": "=3.0.0-pre.25",
     "vscode-uri": "^1.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "fs-extra": "^5.0.0",
     "glob": "^7.1.2",
     "minimatch": "^3.0.4",
-    "polymer-analyzer": "=3.0.0-pre.14",
+    "polymer-analyzer": "=3.0.0-pre.24",
     "vscode-uri": "^1.0.3"
   },
   "devDependencies": {

--- a/src/gen-ts.ts
+++ b/src/gen-ts.ts
@@ -75,7 +75,10 @@ const defaultExclude = [
  */
 export async function generateDeclarations(
     rootDir: string, config: Config): Promise<Map<string, string>> {
-  const a = analyzer.Analyzer.createForDirectory(rootDir);
+  const a = new analyzer.Analyzer({
+   urlLoader: new analyzer.FsUrlLoader(rootDir),
+    urlResolver: new analyzer.PackageUrlResolver({ packageDir: rootDir }),
+  });
   const analysis = await a.analyzePackage();
   const outFiles = new Map<string, string>();
   for (const tsDoc of analyzerToAst(analysis, config, rootDir)) {
@@ -311,7 +314,8 @@ function handleElement(feature: analyzer.Element, root: ts.Document) {
       methods: [
         ...handleMethods(feature.staticMethods.values(), {isStatic: true}),
         ...handleMethods(feature.methods.values()),
-      ]
+      ],
+      constructorMethod: handleConstructorMethod(feature.constructorMethod)
     }));
 
     if (behaviors.length > 0) {
@@ -499,6 +503,7 @@ function handleClass(feature: analyzer.Class, root: ts.Document) {
     ...handleMethods(feature.staticMethods.values(), {isStatic: true}),
     ...handleMethods(feature.methods.values())
   ];
+  m.constructorMethod = handleConstructorMethod(feature.constructorMethod);
   findOrCreateNamespace(root, namespacePath).members.push(m);
 }
 
@@ -565,48 +570,64 @@ function handleMethods(
     if (method.inheritedFrom || method.privacy === 'private') {
       continue;
     }
-    const m = new ts.Method({
-      name: method.name,
-      returns: closureTypeToTypeScript(method.return && method.return.type),
-      returnsDescription: method.return && method.return.desc,
-      isStatic: opts && opts.isStatic,
-    });
-    m.description = method.description || '';
 
-    let requiredAhead = false;
-    for (const param of reverseIter(method.params || [])) {
-      const tsParam = closureParamToTypeScript(param.name, param.type);
-      tsParam.description = param.description || '';
-
-      if (param.defaultValue !== undefined) {
-        // Parameters with default values generally behave like optional
-        // parameters. However, unlike optional parameters, they may be
-        // followed by a required parameter, in which case the default value is
-        // set by explicitly passing undefined.
-        if (!requiredAhead) {
-          tsParam.optional = true;
-        } else {
-          tsParam.type = new ts.UnionType([tsParam.type, ts.undefinedType]);
-        }
-      } else if (!tsParam.optional) {
-        requiredAhead = true;
-      }
-
-      // Analyzer might know this is a rest parameter even if there was no
-      // JSDoc type annotation (or if it was wrong).
-      tsParam.rest = tsParam.rest || !!param.rest;
-      if (tsParam.rest && tsParam.type.kind !== 'array') {
-        // Closure rest parameter types are written without the Array syntax,
-        // but in TypeScript they must be explicitly arrays.
-        tsParam.type = new ts.ArrayType(tsParam.type);
-      }
-
-      m.params.unshift(tsParam);
-    }
-
-    tsMethods.push(m);
+    tsMethods.push(handleMethod(method, opts));
   }
   return tsMethods;
+}
+
+/**
+ * Convert the given Analyzer method to the equivalent TypeScript declaration
+ */
+function handleMethod(method: analyzer.Method, opts?: {isStatic?: boolean}): ts.Method {
+  const m = new ts.Method({
+    name: method.name,
+    returns: closureTypeToTypeScript(method.return && method.return.type),
+    returnsDescription: method.return && method.return.desc,
+    isStatic: opts && opts.isStatic,
+  });
+  m.description = method.description || '';
+
+  let requiredAhead = false;
+  for (const param of reverseIter(method.params || [])) {
+    const tsParam = closureParamToTypeScript(param.name, param.type);
+    tsParam.description = param.description || '';
+
+    if (param.defaultValue !== undefined) {
+      // Parameters with default values generally behave like optional
+      // parameters. However, unlike optional parameters, they may be
+      // followed by a required parameter, in which case the default value is
+      // set by explicitly passing undefined.
+      if (!requiredAhead) {
+        tsParam.optional = true;
+      } else {
+        tsParam.type = new ts.UnionType([tsParam.type, ts.undefinedType]);
+      }
+    } else if (!tsParam.optional) {
+      requiredAhead = true;
+    }
+
+    // Analyzer might know this is a rest parameter even if there was no
+    // JSDoc type annotation (or if it was wrong).
+    tsParam.rest = tsParam.rest || !!param.rest;
+    if (tsParam.rest && tsParam.type.kind !== 'array') {
+      // Closure rest parameter types are written without the Array syntax,
+      // but in TypeScript they must be explicitly arrays.
+      tsParam.type = new ts.ArrayType(tsParam.type);
+    }
+
+    m.params.unshift(tsParam);
+  }
+  return m;
+}
+
+function handleConstructorMethod(method?: analyzer.Method): ts.Method|undefined {
+  if (!method) {
+    return;
+  }
+  const m = handleMethod(method);
+  m.returns = undefined;
+  return m;
 }
 
 /**

--- a/src/gen-ts.ts
+++ b/src/gen-ts.ts
@@ -76,8 +76,8 @@ const defaultExclude = [
 export async function generateDeclarations(
     rootDir: string, config: Config): Promise<Map<string, string>> {
   const a = new analyzer.Analyzer({
-   urlLoader: new analyzer.FsUrlLoader(rootDir),
-    urlResolver: new analyzer.PackageUrlResolver({ packageDir: rootDir }),
+    urlLoader: new analyzer.FsUrlLoader(rootDir),
+    urlResolver: new analyzer.PackageUrlResolver({packageDir: rootDir}),
   });
   const analysis = await a.analyzePackage();
   const outFiles = new Map<string, string>();
@@ -579,7 +579,8 @@ function handleMethods(
 /**
  * Convert the given Analyzer method to the equivalent TypeScript declaration
  */
-function handleMethod(method: analyzer.Method, opts?: {isStatic?: boolean}): ts.Method {
+function handleMethod(
+    method: analyzer.Method, opts?: {isStatic?: boolean}): ts.Method {
   const m = new ts.Method({
     name: method.name,
     returns: closureTypeToTypeScript(method.return && method.return.type),
@@ -621,7 +622,8 @@ function handleMethod(method: analyzer.Method, opts?: {isStatic?: boolean}): ts.
   return m;
 }
 
-function handleConstructorMethod(method?: analyzer.Method): ts.Method|undefined {
+function handleConstructorMethod(method?: analyzer.Method): ts.Method|
+    undefined {
   if (!method) {
     return;
   }

--- a/src/test/fixtures/custom/my-class.js
+++ b/src/test/fixtures/custom/my-class.js
@@ -1,4 +1,11 @@
 class MyClass {
+  /**
+   * @param {number} num
+   * @param {boolean} truth
+   */
+  constructor(num, truth) {
+
+  }
   no_params() { }
 
   one_param(p1) { }

--- a/src/test/goldens/custom/my-class.d.ts
+++ b/src/test/goldens/custom/my-class.d.ts
@@ -9,6 +9,7 @@
  */
 
 declare class MyClass {
+  constructor(num: number, truth: boolean);
   no_params(): void;
   one_param(p1: any): void;
   two_params(p1: any, p2: any): void;

--- a/src/test/goldens/polymer/lib/legacy/polymer.dom.d.ts
+++ b/src/test/goldens/polymer/lib/legacy/polymer.dom.d.ts
@@ -48,6 +48,11 @@ declare namespace Polymer {
     readonly activeElement: Node|null|undefined;
 
     /**
+     * @param node Node for which to create a Polymer.dom helper object.
+     */
+    constructor(node: Node|null);
+
+    /**
      * Returns an instance of `Polymer.FlattenedNodesObserver` that
      * listens for node changes on this element.
      *
@@ -176,4 +181,5 @@ declare class EventApi {
    * Returns the `composedPath` for this event.
    */
   readonly path: Array<EventTarget|null>;
+  constructor(event: any);
 }

--- a/src/test/goldens/polymer/lib/utils/debounce.d.ts
+++ b/src/test/goldens/polymer/lib/utils/debounce.d.ts
@@ -15,6 +15,7 @@
 declare namespace Polymer {
 
   class Debouncer {
+    constructor();
 
     /**
      * Creates a debouncer if no debouncer is passed as a parameter

--- a/src/test/goldens/polymer/lib/utils/flattened-nodes-observer.d.ts
+++ b/src/test/goldens/polymer/lib/utils/flattened-nodes-observer.d.ts
@@ -55,6 +55,13 @@ declare namespace Polymer {
   class FlattenedNodesObserver {
 
     /**
+     * @param target Node on which to listen for changes.
+     * @param callback Function called when there are additions
+     * or removals from the target's list of flattened nodes.
+     */
+    constructor(target: _Element|null, callback: ((p0: _Element, p1: {target: _Element, addedNodes: _Element[], removedNodes: _Element[]}) => void)|null);
+
+    /**
      * Returns the list of flattened nodes for the given `node`.
      * This list consists of a node's children and, for any children
      * that are `<slot>` elements, the expanded flattened list of `assignedNodes`.

--- a/src/test/goldens/polymer/lib/utils/html-tag.d.ts
+++ b/src/test/goldens/polymer/lib/utils/html-tag.d.ts
@@ -17,6 +17,7 @@
  */
 declare class LiteralString {
   value: string;
+  constructor(string: any);
 
   /**
    * @returns LiteralString string value

--- a/src/test/serialize_test.ts
+++ b/src/test/serialize_test.ts
@@ -156,7 +156,6 @@ interface MyInterface {
 declare class MyClass {
 }
 `);
-
   });
 
   test('namespace', () => {


### PR DESCRIPTION
The `constructor` types were missing, they are generated now. They are a special kind of method with no return type (TypeScript disallows this, even though it is technically possible in ES6).

Also update analyzer to fix the creation of the analyzer. `createForDirectory` was later removed from the pre-release.

Requires https://github.com/Polymer/tools/pull/202
Required for https://github.com/Polymer/polymer/issues/5189 

- [X] CHANGELOG.md has been updated
