### PR TITLE
Clarify error message for missing feature names

### DIFF
--- a/src/gen-ts.ts
+++ b/src/gen-ts.ts
@@ -292,7 +292,7 @@ function handleElement(feature: analyzer.Element, root: ts.Document) {
     parent = root;
 
   } else {
-    console.error('Could not find a name.');
+    console.error(`Could not find element name defined in ${feature.sourceRange}`);
     return;
   }
 
@@ -367,7 +367,7 @@ function handleElement(feature: analyzer.Element, root: ts.Document) {
  */
 function handleBehavior(feature: analyzer.PolymerBehavior, root: ts.Document) {
   if (!feature.className) {
-    console.error('Could not find a name for behavior.');
+    console.error(`Could not find a name for behavior defined in ${feature.sourceRange}`);
     return;
   }
 
@@ -488,7 +488,7 @@ function transitiveMixins(
  */
 function handleClass(feature: analyzer.Class, root: ts.Document) {
   if (!feature.className) {
-    console.error('Could not find a name for class.');
+    console.error(`Could not find a name for class defined in ${feature.sourceRange}`);
     return;
   }
   const [namespacePath, name] = splitReference(feature.className);


### PR DESCRIPTION
Adding the `sourceRange` makes debugging of the missing feature a lot easier, as it will now point to the file. I do not remember how I triggered this error, so not sure how to test this :cry: 

Fixes #94 

 - [X] CHANGELOG.md has not been updated, internal change
